### PR TITLE
Fix powerlaw log uniform

### DIFF
--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -25,12 +25,9 @@ def betaln(alpha, beta):
 
 
 def powerlaw(xx, alpha, high, low):
-    if low < 0:
+    if xp.any(low < 0):
         raise ValueError('Parameter low must be greater or equal zero, '
                          'low={}.'.format(low))
-    if high <= low:
-        raise ValueError('Parameter high must be greater than low, low={}, '
-                         'high={}.'.format(low, high))
     if alpha == -1:
         norm = 1 / xp.log(high / low)
     else:

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -15,7 +15,7 @@ def beta_dist(xx, alpha, beta, scale=1):
     ln_beta -= (alpha + beta - 1) * xp.log(scale)
     prob = xp.exp(ln_beta)
     prob = xp.nan_to_num(prob)
-    prob *= (xx <= scale)
+    prob *= (xx >= 0) * (xx <= scale)
     return prob
 
 

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -19,6 +19,12 @@ def betaln(alpha, beta):
 
 
 def powerlaw(xx, alpha, high, low):
+    if low < 0:
+        raise ValueError('Parameter low must be greater or equal zero, '
+                         'low={}.'.format(low))
+    if high <= low:
+        raise ValueError('Parameter high must be greater than low, low={}, '
+                         'high={}.'.format(low, high))
     if alpha == -1:
         norm = 1 / xp.log(high / low)
     else:
@@ -30,6 +36,9 @@ def powerlaw(xx, alpha, high, low):
 
 
 def truncnorm(xx, mu, sigma, high, low):
+    if sigma <= 0:
+        raise ValueError(
+            'Sigma must be greater than 0, sigma={}'.format(sigma))
     norm = 2**0.5 / xp.pi**0.5 / sigma
     norm /= erf((high - mu) / 2**0.5 / sigma) + erf((mu - low) / 2**0.5 / sigma)
     prob = xp.exp(-xp.power(xx - mu, 2) / (2 * sigma**2))

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -4,6 +4,12 @@ from .cupy_utils import erf, gammaln, xp
 
 
 def beta_dist(xx, alpha, beta, scale=1):
+    if alpha < 0:
+        raise ValueError('Parameter alpha must be greater or equal zero, '
+                         'low={}.'.format(alpha))
+    if beta < 0:
+        raise ValueError('Parameter beta must be greater or equal zero, '
+                         'low={}.'.format(beta))
     ln_beta = (alpha - 1) * xp.log(xx) + (beta - 1) * xp.log(scale - xx)
     ln_beta -= betaln(alpha, beta)
     ln_beta -= (alpha + beta - 1) * xp.log(scale)

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -19,7 +19,10 @@ def betaln(alpha, beta):
 
 
 def powerlaw(xx, alpha, high, low):
-    norm = (1 + alpha) / (high**(1 + alpha) - low**(1 + alpha))
+    if alpha == -1:
+        norm = 1 / xp.log(high / low)
+    else:
+        norm = (1 + alpha) / (high**(1 + alpha) - low**(1 + alpha))
     prob = xp.power(xx, alpha)
     prob *= norm
     prob *= (xx <= high) & (xx >= low)

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -31,6 +31,14 @@ class TestBetaDist(unittest.TestCase):
             equal_zero = equal_zero & (vals == 0.0)
         self.assertTrue(equal_zero)
 
+    def test_beta_dist_alpha_below_zero_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            utils.powerlaw(0.5, -1, 0, 1)
+
+    def test_beta_dist_beta_below_zero_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            utils.powerlaw(0.5, 0, -1, 1)
+
 
 class TestPowerLaw(unittest.TestCase):
 

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -1,0 +1,104 @@
+import unittest
+
+import numpy as np
+
+from gwpopulation import utils
+
+
+class TestBetaDist(unittest.TestCase):
+
+    def setUp(self):
+        self.n_test = 100
+        self.alphas = np.random.uniform(0, 10, self.n_test)
+        self.betas = np.random.uniform(0, 10, self.n_test)
+        self.scales = np.random.uniform(0, 10, self.n_test)
+        pass
+
+    def test_beta_dist_zero_below_zero(self):
+        equal_zero = True
+        for ii in range(self.n_test):
+            vals = utils.beta_dist(xx=-1, alpha=self.alphas[ii],
+                                   beta=self.betas[ii], scale=self.scales[ii])
+            equal_zero = equal_zero & (vals == 0.0)
+        self.assertTrue(equal_zero)
+
+    def test_beta_dist_zero_above_scale(self):
+        equal_zero = True
+        for ii in range(self.n_test):
+            xx = self.scales[ii] + 1
+            vals = utils.beta_dist(xx=xx, alpha=self.alphas[ii],
+                                   beta=self.betas[ii], scale=self.scales[ii])
+            equal_zero = equal_zero & (vals == 0.0)
+        self.assertTrue(equal_zero)
+
+
+class TestPowerLaw(unittest.TestCase):
+
+    def setUp(self):
+        self.n_test = 100
+        self.alphas = np.random.uniform(-10, 10, self.n_test)
+        self.lows = np.random.uniform(5, 15, self.n_test)
+        self.highs = np.random.uniform(20, 30, self.n_test)
+        pass
+
+    def test_powerlaw_zero_below_low(self):
+        equal_zero = True
+        for ii in range(self.n_test):
+            xx = self.lows[ii] - 1
+            vals = utils.powerlaw(xx=xx, alpha=self.alphas[ii],
+                                  low=self.lows[ii], high=self.highs[ii])
+            equal_zero = equal_zero & (vals == 0.0)
+        self.assertTrue(equal_zero)
+
+    def test_powerlaw_zero_above_high(self):
+        equal_zero = True
+        for ii in range(self.n_test):
+            xx = self.highs[ii] + 1
+            vals = utils.powerlaw(xx=xx, alpha=self.alphas[ii],
+                                  low=self.lows[ii], high=self.highs[ii])
+            equal_zero = equal_zero & (vals == 0.0)
+        self.assertTrue(equal_zero)
+
+    def test_powerlaw_low_below_zero_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            utils.powerlaw(0, 3, 10, -4)
+
+    def test_powerlaw_high_below_low_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            utils.powerlaw(10, 3, 10, 20)
+
+
+class TestTruncNorm(unittest.TestCase):
+
+    def setUp(self):
+        self.n_test = 100
+        self.mus = np.random.uniform(-10, 10, self.n_test)
+        self.sigmas = np.random.uniform(0, 10, self.n_test)
+        self.lows = np.random.uniform(-30, -20, self.n_test)
+        self.highs = np.random.uniform(20, 30, self.n_test)
+        pass
+
+    def test_truncnorm_zero_below_low(self):
+        equal_zero = True
+        for ii in range(self.n_test):
+            xx = self.lows[ii] - 1
+            vals = utils.truncnorm(
+                xx=xx, mu=self.mus[ii], sigma=self.sigmas[ii],
+                low=self.lows[ii], high=self.highs[ii])
+            equal_zero = equal_zero & (vals == 0.0)
+        self.assertTrue(equal_zero)
+
+    def test_truncnorm_zero_above_high(self):
+        equal_zero = True
+        for ii in range(self.n_test):
+            xx = self.highs[ii] + 1
+            vals = utils.truncnorm(
+                xx=xx, mu=self.mus[ii], sigma=self.sigmas[ii],
+                low=self.lows[ii], high=self.highs[ii])
+            equal_zero = equal_zero & (vals == 0.0)
+        self.assertTrue(equal_zero)
+
+    def test_truncnorm_sigma_below_zero_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            utils.truncnorm(0, 0, -1, 10, -10)
+

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -33,11 +33,11 @@ class TestBetaDist(unittest.TestCase):
 
     def test_beta_dist_alpha_below_zero_raises_value_error(self):
         with self.assertRaises(ValueError):
-            utils.powerlaw(0.5, -1, 0, 1)
+            utils.beta_dist(xx=0.5, alpha=-1, beta=1, scale=1)
 
     def test_beta_dist_beta_below_zero_raises_value_error(self):
         with self.assertRaises(ValueError):
-            utils.powerlaw(0.5, 0, -1, 1)
+            utils.beta_dist(xx=0.5, alpha=1, beta=-1, scale=1)
 
 
 class TestPowerLaw(unittest.TestCase):
@@ -70,10 +70,6 @@ class TestPowerLaw(unittest.TestCase):
     def test_powerlaw_low_below_zero_raises_value_error(self):
         with self.assertRaises(ValueError):
             utils.powerlaw(0, 3, 10, -4)
-
-    def test_powerlaw_high_below_low_raises_value_error(self):
-        with self.assertRaises(ValueError):
-            utils.powerlaw(10, 3, 10, 20)
 
 
 class TestTruncNorm(unittest.TestCase):

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -69,7 +69,11 @@ class TestPowerLaw(unittest.TestCase):
 
     def test_powerlaw_low_below_zero_raises_value_error(self):
         with self.assertRaises(ValueError):
-            utils.powerlaw(0, 3, 10, -4)
+            utils.powerlaw(xx=0, alpha=3, high=10, low=-4)
+
+    def test_powerlaw_alpha_equal_zero(self):
+        self.assertEqual(utils.powerlaw(xx=1.0, alpha=-1, low=0.5, high=2),
+                         1 / np.log(4))
 
 
 class TestTruncNorm(unittest.TestCase):
@@ -104,5 +108,5 @@ class TestTruncNorm(unittest.TestCase):
 
     def test_truncnorm_sigma_below_zero_raises_value_error(self):
         with self.assertRaises(ValueError):
-            utils.truncnorm(0, 0, -1, 10, -10)
+            utils.truncnorm(xx=0, mu=0, sigma=-1, high=10, low=-10)
 


### PR DESCRIPTION
The powerlaw distribution failed for alpha=-1 due to not accounting for the special case.