### PR TITLE
begin deprecating sampling_prior argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ def readfile(filename):
     return filecontents
 
 
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 version_file = write_version_file(VERSION)
 long_description = get_long_description()
 


### PR DESCRIPTION
Remove the `sampling_prior` argument from the likelihoods.