### PR TITLE
AssertionError on some installations

### DIFF
--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -25,7 +25,7 @@ def betaln(alpha, beta):
 
 
 def powerlaw(xx, alpha, high, low):
-    if xp.any(xp.asarry(low) < 0):
+    if xp.any(xp.asarray(low) < 0):
         raise ValueError('Parameter low must be greater or equal zero, '
                          'low={}.'.format(low))
     if alpha == -1:

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -25,7 +25,7 @@ def betaln(alpha, beta):
 
 
 def powerlaw(xx, alpha, high, low):
-    if xp.any(xp.asarry(low < 0)):
+    if xp.any(xp.asarry(low) < 0):
         raise ValueError('Parameter low must be greater or equal zero, '
                          'low={}.'.format(low))
     if alpha == -1:

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -25,7 +25,7 @@ def betaln(alpha, beta):
 
 
 def powerlaw(xx, alpha, high, low):
-    if xp.any(low < 0):
+    if xp.any(xp.asarry(low < 0)):
         raise ValueError('Parameter low must be greater or equal zero, '
                          'low={}.'.format(low))
     if alpha == -1:


### PR DESCRIPTION
Received this error with vanilla installation. Fixed when forcing low to xp.asarray(low), 
 File "/home/cbk632/.conda/envs/second_gen/lib/python3.6/site-packages/gwpopula
tion/utils.py", line 28, in powerlaw
    if xp.any(low < 0):
  File "/home/cbk632/.conda/envs/second_gen/lib/python3.6/site-packages/cupy/log
ic/truth.py", line 58, in any
    assert isinstance(a, cupy.ndarray)
AssertionError
