### PR TITLE
Edit _compute_per_event_ln_bayes_factors to include number of samples

### DIFF
--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -106,15 +106,12 @@ class HyperparameterLikelihood(Likelihood):
         self.selection_function = selection_function
 
         self.n_posteriors = len(posteriors)
-        self.samples_factor =\
-            - self.n_posteriors * np.log(self.samples_per_posterior)
 
     def log_likelihood_ratio(self):
         self.parameters, added_keys = self.conversion_function(self.parameters)
         self.hyper_prior.parameters.update(self.parameters)
         ln_l = xp.sum(self._compute_per_event_ln_bayes_factors())
         ln_l += self._get_selection_factor()
-        ln_l += self.samples_factor
         if added_keys is not None:
             for key in added_keys:
                 self.parameters.pop(key)
@@ -127,8 +124,9 @@ class HyperparameterLikelihood(Likelihood):
         return self.noise_log_likelihood() + self.log_likelihood_ratio()
 
     def _compute_per_event_ln_bayes_factors(self):
-        return xp.log(xp.sum(self.hyper_prior.prob(self.data) /
-                             self.sampling_prior, axis=-1))
+        return - np.log(self.samples_per_posterior) + xp.log(
+            xp.sum(self.hyper_prior.prob(self.data) /
+                   self.sampling_prior, axis=-1))
 
     def _get_selection_factor(self):
         return - self.n_posteriors * xp.log(
@@ -226,7 +224,7 @@ class HyperparameterLikelihood(Likelihood):
                 self.parameters
             )
             new_weights = (
-                    self.hyper_prior.prob(self.data) / self.sampling_prior
+                self.hyper_prior.prob(self.data) / self.sampling_prior
             )
             event_weights += xp.mean(new_weights, axis=-1)
             new_weights = (new_weights.T / xp.sum(new_weights, axis=-1)).T

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -149,9 +149,9 @@ class Likelihoods(unittest.TestCase):
         new_params = like.generate_extra_statistics(sample=self.params.copy())
         expected = {
             'a': 1, 'b': 1, 'c': 1,
-            'ln_bf_0': 6.214608098422191, 'ln_bf_1': 6.214608098422191,
-            'ln_bf_2': 6.214608098422191, 'ln_bf_3': 6.214608098422191,
-            'ln_bf_4': 6.214608098422191, 'selection': 2.0, 'bar': None
+            'ln_bf_0': 0.0, 'ln_bf_1': 0.0,
+            'ln_bf_2': 0.0, 'ln_bf_3': 0.0,
+            'ln_bf_4': 0.0, 'selection': 2.0, 'bar': None
         }
         self.assertDictEqual(expected, new_params)
 


### PR DESCRIPTION
Removes `samples_factor` and includes the calculation in the `_compute_per_event_ln_bayes_factors`.

This makes sure the `generate_extra_statistics` function includes the 1/samples term.