### PR TITLE
Add hyper_prior compatibility with `gwdistributions` classes

### DIFF
--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import types
 from tqdm import tqdm
 
 from bilby.core.utils import logger
@@ -87,7 +88,7 @@ class HyperparameterLikelihood(Likelihood):
         self.samples_per_posterior = max_samples
         self.data = self.resample_posteriors(posteriors, max_samples=max_samples)
 
-        if not isinstance(hyper_prior, Model):
+        if isinstance(hyper_prior, types.FunctionType):
             hyper_prior = Model([hyper_prior])
         self.hyper_prior = hyper_prior
         Likelihood.__init__(self, hyper_prior.parameters)

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -90,6 +90,11 @@ class HyperparameterLikelihood(Likelihood):
 
         if isinstance(hyper_prior, types.FunctionType):
             hyper_prior = Model([hyper_prior])
+        elif not (hasattr(hyper_prior, 'parameters') and callable(getattr(hyper_prior,'prob'))):
+            raise AttributeError(
+                "hyper_prior must either be a function, "
+                "or a class with attribute 'parameters' and method 'prob'"
+            )
         self.hyper_prior = hyper_prior
         Likelihood.__init__(self, hyper_prior.parameters)
 


### PR DESCRIPTION
As of right now, the `HyperparameterLikelihood` class in `gwpopulation` wraps any input models (`hyper_prior`) in `bilby`'s `Model` class if those input models are not already Model() classes. However, `gwdistributions` population models are either `SamplingDistribution` or `EventGenerator` classes, which have the same methods as `Model` plus more functionality, so they should not be wrapped in the `Model` class. This PR presents a simple solution, suggested by @reedessick, where functions passed as `hyper_prior`s to 'HyperparameterLikelihood` are still wrapped in the `Model` class, but other types (i.e. classes) are not wrapped.

