### PR TITLE
Remove redshift duplicate

### DIFF
--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -78,7 +78,7 @@ class _Redshift(object):
         return self.normalisation(parameters=parameters)
 
     total_spacetime_volume.__doc__ = (
-        b"Deprecated use normalisation instead.\n" + normalisation.__doc__
+        "Deprecated use normalisation instead.\n" + normalisation.__doc__
     )
 
 

--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -31,7 +31,7 @@ class _Redshift(object):
         """
         Compute the normalization or differential spacetime volume.
 
-        d\mathcal{V} = \frac{1}{1+z} \frac{dVc}{dz} \psi(z|\Lambda)
+        \mathcal{V} = \int dz \frac{1}{1+z} \frac{dVc}{dz} \psi(z|\Lambda)
 
         Parameters
         ----------
@@ -57,6 +57,22 @@ class _Redshift(object):
         raise NotImplementedError
 
     def differential_spacetime_volume(self, dataset, **parameters):
+        """
+        Compute the differential spacetime volume.
+
+        d\mathcal{V} = \frac{1}{1+z} \frac{dVc}{dz} \psi(z|\Lambda)
+
+        Parameters
+        ----------
+        dataset: dict
+            Dictionary containing entry "redshift"
+        parameters: dict
+            Dictionary of parameters
+        Returns
+        -------
+        differential_volume: (float, array-like)
+            Differential spacetime volume
+        """
         psi_of_z = self.psi_of_z(redshift=dataset["redshift"], **parameters)
         differential_volume = psi_of_z / (1 + dataset["redshift"])
         try:
@@ -68,18 +84,16 @@ class _Redshift(object):
 
     def total_spacetime_volume(self, **parameters):
         """
-        See normalisation
-        """
+        Deprecated use normalisation instead.
+
+        {}
+        """.format(_Redshift.normalisation.__doc__)
         warn(
             "The total spacetime volume method is deprecated, "
             "use normalisation instead.",
             DeprecationWarning
         )
         return self.normalisation(parameters=parameters)
-
-    total_spacetime_volume.__doc__ = (
-        "Deprecated use normalisation instead.\n" + normalisation.__doc__
-    )
 
 
 class PowerLawRedshift(_Redshift):

--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -1,8 +1,9 @@
-from ..cupy_utils import to_numpy, trapz, xp
-
-import numpy as np
+from warnings import warn
 
 from astropy.cosmology import Planck15
+import numpy as np
+
+from ..cupy_utils import to_numpy, trapz, xp
 
 
 class _Redshift(object):
@@ -27,6 +28,20 @@ class _Redshift(object):
         )
 
     def normalisation(self, parameters):
+        """
+        Compute the normalization or differential spacetime volume.
+
+        d\mathcal{V} = \frac{1}{1+z} \frac{dVc}{dz} \psi(z|\Lambda)
+
+        Parameters
+        ----------
+        parameters: dict
+            Dictionary of parameters
+
+        Returns
+        -------
+        (float, array-like): Total spacetime volume
+        """
         psi_of_z = self.psi_of_z(redshift=self.zs, **parameters)
         norm = trapz(psi_of_z * self.dvc_dz / (1 + self.zs), self.zs)
         return norm
@@ -42,23 +57,6 @@ class _Redshift(object):
         raise NotImplementedError
 
     def differential_spacetime_volume(self, dataset, **parameters):
-        """
-        Compute the differential spacetime volume.
-
-        d\mathcal{V} = \frac{1}{1+z} \frac{dVc}{dz} \psi(z|\Lambda)
-
-        Parameters
-        ----------
-        dataset: dict
-            Dictionary containing entry "redshift"
-        parameters: dict
-            Dictionary of parameters
-
-        Returns
-        -------
-        differential_volume: (float, array-like)
-            Differential spacetime volume
-        """
         psi_of_z = self.psi_of_z(redshift=dataset["redshift"], **parameters)
         differential_volume = psi_of_z / (1 + dataset["redshift"])
         try:
@@ -70,23 +68,18 @@ class _Redshift(object):
 
     def total_spacetime_volume(self, **parameters):
         """
-        Compute the total enclosed spacetime volume.
-
-        \mathcal{V} = \int dz \frac{1}{1+z} \frac{dVc}{dz} \psi(z|\Lambda)
-
-        Parameters
-        ----------
-        parameters: dict
-            Dictionary of parameters
-
-        Returns
-        -------
-        float: the total enclosed spacetime volume
+        See normalisation
         """
-        differential_volume = (
-            self.psi_of_z(redshift=self.zs, **parameters) / (1 + self.zs) * self.dvc_dz
+        warn(
+            "The total spacetime volume method is deprecated, "
+            "use normalisation instead.",
+            DeprecationWarning
         )
-        return trapz(differential_volume, self.zs)
+        return self.normalisation(parameters=parameters)
+
+    total_spacetime_volume.__doc__ = (
+        b"Deprecated use normalisation instead.\n" + normalisation.__doc__
+    )
 
 
 class PowerLawRedshift(_Redshift):

--- a/gwpopulation/vt.py
+++ b/gwpopulation/vt.py
@@ -88,7 +88,7 @@ class ResamplingVT(_BaseVT):
             return self._surveyed_hypervolume
         else:
             return (
-                self.redshift_model.total_spacetime_volume(**parameters)
+                self.redshift_model.normalisation(parameters)
                 / 1e9
                 * self.analysis_time
             )

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -173,15 +173,14 @@ class Likelihoods(unittest.TestCase):
         }
         self.assertDictEqual(expected, new_params)
 
-    def test_generate_rate_posterior_sample_raises_error(self):
+    def test_generate_rate_posterior_sample_returns_positive(self):
         like = HyperparameterLikelihood(
             posteriors=self.data,
             hyper_prior=self.model,
             selection_function=self.selection_function,
             ln_evidences=self.ln_evidences,
         )
-        with self.assertRaises(NotImplementedError):
-            like.generate_rate_posterior_sample()
+        self.assertGreater(like.generate_rate_posterior_sample(), 0)
 
     def test_resampling_posteriors(self):
         priors = PriorDict(dict(a=Uniform(0, 2), b=Uniform(0, 2), c=Uniform(0, 2)))


### PR DESCRIPTION
The `total_spacetime_volume` and `normalisation` methods were doing the same thing.