### PR TITLE
fix application of bounds in redshift model

### DIFF
--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -28,7 +28,7 @@ class _Redshift(object):
 
     def _cache_dvc_dz(self, redshifts):
         self.cached_dvc_dz = xp.asarray(
-            np.interp(to_numpy(redshifts), self.zs_, self.dvc_dz_, left0, right=0)
+            np.interp(to_numpy(redshifts), self.zs_, self.dvc_dz_, left=0, right=0)
         )
 
     def normalisation(self, parameters):

--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -28,7 +28,7 @@ class _Redshift(object):
 
     def _cache_dvc_dz(self, redshifts):
         self.cached_dvc_dz = xp.asarray(
-            np.interp(to_numpy(redshifts), self.zs_, self.dvc_dz_)
+            np.interp(to_numpy(redshifts), self.zs_, self.dvc_dz_, left0, right=0)
         )
 
     def normalisation(self, parameters):
@@ -56,7 +56,8 @@ class _Redshift(object):
         differential_volume = self.differential_spacetime_volume(
             dataset=dataset, **parameters
         )
-        return differential_volume / normalisation
+        in_bounds = dataset["redshift"] <= self.z_max
+        return differential_volume / normalisation * in_bounds
 
     def psi_of_z(self, redshift, **parameters):
         raise NotImplementedError
@@ -89,13 +90,11 @@ class _Redshift(object):
         return differential_volume
 
     def total_spacetime_volume(self, **parameters):
-        """
+        f"""
         Deprecated use normalisation instead.
 
-        {}
-        """.format(
-            _Redshift.normalisation.__doc__
-        )
+        {_Redshift.normalisation.__doc__}
+        """
         warn(
             "The total spacetime volume method is deprecated, "
             "use normalisation instead.",

--- a/test/redshift_test.py
+++ b/test/redshift_test.py
@@ -51,6 +51,12 @@ class TestRedshift(unittest.TestCase):
             model.total_spacetime_volume(**parameters),
         )
 
+    def test_zero_outside_domain(self):
+        model = redshift.PowerLawRedshift(z_max=1)
+        parameters = dict(lamb=1)
+        p_z = model(self.test_data, **parameters)
+        self.assertTrue(all(p_z[self.zs > 1] == 0))
+
 
 class TestFourVolume(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Currently `z_max` is not applied properly in the `Redshift` models, see the plot below. This PR will fix that.

![image](https://user-images.githubusercontent.com/25602909/126662838-d01e7304-88c6-44ce-b89f-27da8733afde.png)
