### PR TITLE
add meta data to likelihood

### DIFF
--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -81,7 +81,7 @@ class HyperparameterLikelihood(Likelihood):
                 "or a class with attribute 'parameters' and method 'prob'"
             )
         self.hyper_prior = hyper_prior
-        Likelihood.__init__(self, hyper_prior.parameters)
+        super(HyperparameterLikelihood, self).__init__(hyper_prior.parameters)
 
         if "prior" in self.data:
             self.sampling_prior = self.data.pop("prior")
@@ -284,6 +284,16 @@ class HyperparameterLikelihood(Likelihood):
             return new_samples, weights
         else:
             return new_samples
+
+    @property
+    def meta_data(self):
+        return dict(
+            model=[model.__name__ for model in self.hyper_prior.models],
+            data={key: to_numpy(self.data[key]) for key in self.data},
+            n_events=self.n_posteriors,
+            sampling_prior=to_numpy(self.sampling_prior),
+            samples_per_posterior=self.samples_per_posterior,
+        )
 
 
 class RateLikelihood(HyperparameterLikelihood):

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -194,3 +194,30 @@ class Likelihoods(unittest.TestCase):
         new_samples = like.posterior_predictive_resample(samples=samples)
         for key in new_samples:
             self.assertEqual(new_samples[key].shape, like.data[key].shape)
+
+    def test_meta_data(self):
+        like = HyperparameterLikelihood(
+            posteriors=self.data,
+            hyper_prior=self.model,
+            selection_function=self.selection_function,
+            ln_evidences=self.ln_evidences,
+        )
+        expected = dict(
+            model=["<lambda>"],
+            data=dict(
+                a=np.ones((5, 500)),
+                b=np.ones((5, 500)),
+                c=np.ones((5, 500)),
+            ),
+            n_events=5,
+            sampling_prior=1,
+            samples_per_posterior=500
+        )
+        for key in like.meta_data:
+            if key == "data":
+                for key_2 in like.meta_data[key]:
+                    self.assertTrue(np.max(abs(
+                        like.meta_data[key][key_2] - expected[key][key_2]
+                    )) == 0)
+            else:
+                self.assertEqual(like.meta_data[key], expected[key])


### PR DESCRIPTION
This PR adds some metadata to the likelihood object, this will automatically be stored in a `Bilby` result and will help make it easier to do various bits of post-processing.