### PR TITLE
fixes for updated cupy/python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@
 language: python
 
 python:
-  - "3.6"
-  - "3.7"
+  - "3.8"
+  - "3.9"
 
 cache: pip
 
@@ -24,7 +24,7 @@ before_install:
 install:
   - pip install --upgrade -r requirements.txt
   - pip install -r pages_requirements.txt
-  - pip install "coverage<4.4" "pytest-cov<2.5" codeclimate-test-reporter
+  - pip install coverage pytest-cov codeclimate-test-reporter
   - pip install .
 
 script:
@@ -50,4 +50,4 @@ deploy:
   keep-history: true
   on:
     branch: master
-    python: "3.7"
+    python: "3.9"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,9 +54,9 @@ source_suffix = [".txt", ".ipynb", ".rst"]
 master_doc = "index"
 
 # General information about the project.
-project = u"GWPopulation"
-copyright = u"2021, Colm Talbot"
-author = u"Colm Talbot"
+project = "GWPopulation"
+copyright = "2021, Colm Talbot"
+author = "Colm Talbot"
 
 
 # The version info for the project you're documenting, acts as replacement for
@@ -153,8 +153,8 @@ latex_documents = [
     (
         master_doc,
         "gwpopulation.tex",
-        u"GWPopulation Documentation",
-        u"Colm Talbot",
+        "GWPopulation Documentation",
+        "Colm Talbot",
         "manual",
     ),
 ]
@@ -164,7 +164,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "GWPopulation", u"GWPopulation Documentation", [author], 1)]
+man_pages = [(master_doc, "GWPopulation", "GWPopulation Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -176,7 +176,7 @@ texinfo_documents = [
     (
         master_doc,
         "GWPopulation",
-        u"GWPopulation Documentation",
+        "GWPopulation Documentation",
         author,
         "Colm Talbot",
         "Population models for gravitational waves.",

--- a/gwpopulation/conversions.py
+++ b/gwpopulation/conversions.py
@@ -93,7 +93,7 @@ def alpha_beta_max_to_mu_var_max(alpha, beta, amax):
         The maximum spin (:math:`a_\max`)
     """
     mu = alpha / (alpha + beta) * amax
-    var = alpha * beta / ((alpha + beta) ** 2 * (alpha + beta + 1)) * amax ** 2
+    var = alpha * beta / ((alpha + beta) ** 2 * (alpha + beta + 1)) * amax**2
     return mu, var, amax
 
 
@@ -125,7 +125,7 @@ def mu_var_max_to_alpha_beta_max(mu, var, amax):
         The maximum spin (:math:`a_\max`)
     """
     mu /= amax
-    var /= amax ** 2
-    alpha = (mu ** 2 * (1 - mu) - mu * var) / var
+    var /= amax**2
+    alpha = (mu**2 * (1 - mu) - mu * var) / var
     beta = (mu * (1 - mu) ** 2 - (1 - mu) * var) / var
     return alpha, beta, amax

--- a/gwpopulation/cupy_utils.py
+++ b/gwpopulation/cupy_utils.py
@@ -4,12 +4,12 @@ Helper functions for missing functionality in cupy.
 
 try:
     import cupy as xp
-    from cupyx.scipy.special import erf, gammaln
+    from cupyx.scipy.special import erf, gammaln  # noqa
 
     CUPY_LOADED = True
 except ImportError:
     import numpy as xp
-    from scipy.special import erf, gammaln
+    from scipy.special import erf, gammaln  # noqa
 
     CUPY_LOADED = False
 
@@ -106,9 +106,9 @@ def trapz(y, x=None, dx=1.0, axis=-1):
             d = d.reshape(shape)
         else:
             d = xp.diff(x, axis=axis)
-    nd = y.ndim
-    slice1 = [slice(None)] * nd
-    slice2 = [slice(None)] * nd
+    ndim = y.ndim
+    slice1 = [slice(None)] * ndim
+    slice2 = [slice(None)] * ndim
     slice1[axis] = slice(1, None)
     slice2[axis] = slice(None, -1)
     product = d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -15,7 +15,7 @@ from bilby.hyper.model import Model
 
 from .cupy_utils import CUPY_LOADED, to_numpy, xp
 
-INF = xp.nan_to_num(xp.inf)
+INF = np.nan_to_num(np.inf)
 
 
 class HyperparameterLikelihood(Likelihood):
@@ -110,7 +110,7 @@ class HyperparameterLikelihood(Likelihood):
             for key in added_keys:
                 self.parameters.pop(key)
         if xp.isnan(ln_l):
-            return float(-INF)
+            return -INF
         else:
             return float(xp.nan_to_num(ln_l))
 

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -92,7 +92,7 @@ def double_power_law_peak_primary_mass(
     mpp: float
         Mean of the Gaussian component (:math:`\mu_m`).
     sigpp: float
-        Standard deviation fo the Gaussian component (:math:`\sigma_m`).
+        Standard deviation of the Gaussian component (:math:`\sigma_m`).
     gaussian_mass_maximum: float, optional
         Upper truncation limit of the Gaussian component. (default: 100)
     """
@@ -371,7 +371,7 @@ def two_component_primary_mass_ratio(
     mpp: float
         Mean of the Gaussian component.
     sigpp: float
-        Standard deviation fo the Gaussian component.
+        Standard deviation of the Gaussian component.
     gaussian_mass_maximum: float, optional
         Upper truncation limit of the Gaussian component. (default: 100)
     """
@@ -416,7 +416,7 @@ def two_component_primary_secondary_independent(
     mpp: float
         Mean of the Gaussian component.
     sigpp: float
-        Standard deviation fo the Gaussian component.
+        Standard deviation of the Gaussian component.
     gaussian_mass_maximum: float, optional
         Upper truncation limit of the Gaussian component. (default: 100)
     """
@@ -460,7 +460,7 @@ def two_component_primary_secondary_identical(
     mpp: float
         Mean of the Gaussian component.
     sigpp: float
-        Standard deviation fo the Gaussian component.
+        Standard deviation of the Gaussian component.
     gaussian_mass_maximum: float, optional
         Upper truncation limit of the Gaussian component. (default: 100)
     """
@@ -579,7 +579,7 @@ class BaseSmoothedMassDistribution(object):
         Cache the information necessary for linear interpolation of the mass
         ratio normalisation
         """
-        self.n_below = xp.zeros_like(masses, dtype=xp.int) - 1
+        self.n_below = xp.zeros_like(masses, dtype=int) - 1
         m_below = xp.zeros_like(masses)
         for mm in self.m1s:
             self.n_below += masses > mm
@@ -648,7 +648,7 @@ class SinglePeakSmoothedMassDistribution(BaseSmoothedMassDistribution):
         mpp: float
             Mean of the Gaussian component.
         sigpp: float
-            Standard deviation fo the Gaussian component.
+            Standard deviation of the Gaussian component.
         delta_m: float
             Rise length of the low end of the mass distribution.
 
@@ -783,7 +783,7 @@ class BrokenPowerLawSmoothedMassDistribution(BaseSmoothedMassDistribution):
         mpp: float
             Mean of the Gaussian component.
         sigpp: float
-            Standard deviation fo the Gaussian component.
+            Standard deviation of the Gaussian component.
         delta_m: float
             Rise length of the low end of the mass distribution.
         """
@@ -842,7 +842,7 @@ class BrokenPowerLawPeakSmoothedMassDistribution(BaseSmoothedMassDistribution):
         mpp: float
             Mean of the Gaussian component.
         sigpp: float
-            Standard deviation fo the Gaussian component.
+            Standard deviation of the Gaussian component.
         delta_m: float
             Rise length of the low end of the mass distribution.
 

--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -2,8 +2,6 @@
 Implemented redshift models
 """
 
-from warnings import warn
-
 from astropy.cosmology import Planck15
 import numpy as np
 
@@ -88,19 +86,6 @@ class _Redshift(object):
             self._cache_dvc_dz(dataset["redshift"])
             differential_volume *= self.cached_dvc_dz
         return differential_volume
-
-    def total_spacetime_volume(self, **parameters):
-        f"""
-        Deprecated use normalisation instead.
-
-        {_Redshift.normalisation.__doc__}
-        """
-        warn(
-            "The total spacetime volume method is deprecated, "
-            "use normalisation instead.",
-            DeprecationWarning,
-        )
-        return self.normalisation(parameters=parameters)
 
 
 class PowerLawRedshift(_Redshift):

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -111,20 +111,20 @@ def truncnorm(xx, mu, sigma, high, low):
     """
     if sigma <= 0:
         raise ValueError(f"Sigma must be greater than 0, sigma={sigma}")
-    norm = 2 ** 0.5 / xp.pi ** 0.5 / sigma
-    norm /= erf((high - mu) / 2 ** 0.5 / sigma) + erf((mu - low) / 2 ** 0.5 / sigma)
-    prob = xp.exp(-xp.power(xx - mu, 2) / (2 * sigma ** 2))
+    norm = 2**0.5 / xp.pi**0.5 / sigma
+    norm /= erf((high - mu) / 2**0.5 / sigma) + erf((mu - low) / 2**0.5 / sigma)
+    prob = xp.exp(-xp.power(xx - mu, 2) / (2 * sigma**2))
     prob *= norm
     prob *= (xx <= high) & (xx >= low)
     return prob
 
 
 def unnormalized_2d_gaussian(xx, yy, mu_x, mu_y, sigma_x, sigma_y, covariance):
-    determinant = sigma_x ** 2 * sigma_y ** 2 * (1 - covariance)
+    determinant = sigma_x**2 * sigma_y**2 * (1 - covariance)
     residual_x = (mu_x - xx) * sigma_x
     residual_y = (mu_y - yy) * sigma_y
     prob = xp.exp(
-        -(residual_x ** 2 + residual_y ** 2 - 2 * residual_x * residual_y * covariance)
+        -(residual_x**2 + residual_y**2 - 2 * residual_x * residual_y * covariance)
         / 2
         / determinant
     )

--- a/gwpopulation/vt.py
+++ b/gwpopulation/vt.py
@@ -97,9 +97,9 @@ class ResamplingVT(_BaseVT):
             The population parameters
         """
         mu, var = self.detection_efficiency(parameters)
-        if mu ** 2 <= 4 * self.n_events * var:
+        if mu**2 <= 4 * self.n_events * var:
             return np.inf
-        n_effective = mu ** 2 / var
+        n_effective = mu**2 / var
         vt_factor = mu / np.exp((3 + self.n_events) / 2 / n_effective)
         return vt_factor
 
@@ -108,8 +108,8 @@ class ResamplingVT(_BaseVT):
         weights = self.model.prob(self.data) / self.data["prior"]
         mu = float(xp.sum(weights) / self.total_injections)
         var = float(
-            xp.sum(weights ** 2) / self.total_injections ** 2
-            - mu ** 2 / self.total_injections
+            xp.sum(weights**2) / self.total_injections**2
+            - mu**2 / self.total_injections
         )
         return mu, var
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 exclude = .git,build,dist,docs,test,*__init__.py
-max-line-length = 80
-ignore = E129 W504
+max-line-length = 120
+ignore = E129 W503
 
 [tool:pytest]
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def write_version_file(version):
 
 
 def get_long_description():
-    """ Finds the README and reads in the description """
+    """Finds the README and reads in the description"""
     here = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(here, "README.md")) as f:
         long_description = f.read()
@@ -69,7 +69,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ColmTalbot/gwpopulation",
     author="Colm Talbot",
-    author_email="colm.talbot@monash.edu",
+    author_email="talbotcolm@gmail.com",
     license="MIT",
     version=VERSION,
     packages=find_packages(exclude=["test", "venv", "priors"]),
@@ -77,11 +77,10 @@ setup(
     package_data={"gwpopulation": [version_file]},
     install_requires=["future", "numpy", "scipy", "astropy", "bilby"],
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -91,6 +91,12 @@ class Likelihoods(unittest.TestCase):
         like.parameters.update(self.params)
         self.assertEqual(like.log_likelihood_ratio(), 0.0)
 
+    def test_hpe_likelihood_converts_nan_to_neginf(self):
+        like = HyperparameterLikelihood(posteriors=self.data, hyper_prior=self.model)
+        like._get_selection_factor = lambda *args, **kwargs: np.nan
+        like.parameters.update(self.params)
+        self.assertEqual(like.log_likelihood_ratio(), np.nan_to_num(-np.inf))
+
     def test_hpe_likelihood_noise_likelihood_ratio(self):
         like = HyperparameterLikelihood(
             posteriors=self.data,

--- a/test/redshift_test.py
+++ b/test/redshift_test.py
@@ -46,10 +46,7 @@ class TestRedshift(unittest.TestCase):
             Planck15.differential_comoving_volume(self.zs).value * 4 * np.pi,
             self.zs,
         )
-        self.assertEqual(
-            total_volume,
-            model.total_spacetime_volume(**parameters),
-        )
+        self.assertEqual(total_volume, model.normalisation(parameters))
 
     def test_zero_outside_domain(self):
         model = redshift.PowerLawRedshift(z_max=1)


### PR DESCRIPTION
- Require `Python>=3.8`
- Allow `cupy>=10.1`
- Typo fixes