### PR TITLE
Fix jupyter docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           conda install --file requirements.txt
           conda install --file pages_requirements.txt
-          conda install .
+          python -m pip install .
 
       - name: Build documentation
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,28 +25,16 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*equirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+      - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
 
       - name: Install dependencies
         run: |
-          python -m pip install -r ./requirements.txt
-          python -m pip install -r ./pages_requirements.txt
-          python -m pip install .
+          conda install --file requirements.txt
+          conda install --file pages_requirements.txt
+          conda install .
 
       - name: Build documentation
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,9 +26,10 @@ jobs:
           python-version: '3.9'
 
       - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+        run: |
+          # $CONDA is an environment variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+          conda config --add channels conda-forge
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,20 +41,21 @@ jobs:
       run: |
         conda install flake8 pytest-cov
         conda install --file requirements.txt
-        conda install pre-commit
+        conda install pre-commit codespell
         conda install jupyter
+        pre-commit install
     - name: Install gwpopulation
       run: |
         python -m pip install .
+    - name: List installed
+      run: |
+        python -m pip list
     - name: Run pre-commit checks
       run: |
         pre-commit run --all-files --verbose --show-diff-on-failure
         jupyter nbconvert --clear-output --inplace examples/*.ipynb
         codespell examples/*.ipynb -L "hist"
         git reset --hard
-    - name: List installed
-      run: |
-        python -m pip list
     - name: Test with pytest
       run: |
         pytest --cov gwpopulation -ra --color yes --cov-report=xml --junitxml=pytest.xml

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,17 +32,21 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install flake8 pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        conda install flake8 pytest-cov
+        conda install --file requirements.txt
+        conda install pre-commit
+        conda install jupyter
     - name: Install gwpopulation
       run: |
-        python -m pip install .
+        conda install .
     - name: Run pre-commit checks
       run: |
-        python -m pip install pre-commit
         pre-commit run --all-files --verbose --show-diff-on-failure
         jupyter nbconvert --clear-output --inplace **.ipynb
         codespell **.ipynb -L "hist"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,9 @@ jobs:
       run: |
         python -m pip install pre-commit
         pre-commit run --all-files --verbose --show-diff-on-failure
+        jupyter nbconvert --clear-output --inplace **.ipynb
+        codespell **.ipynb -L "hist"
+        git reset --hard
     - name: List installed
       run: |
         python -m pip list

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Run pre-commit checks
       run: |
         pre-commit run --all-files --verbose --show-diff-on-failure
-        jupyter nbconvert --clear-output --inplace **.ipynb
-        codespell **.ipynb -L "hist"
+        jupyter nbconvert --clear-output --inplace examples/*.ipynb
+        codespell examples/*.ipynb -L "hist"
         git reset --hard
     - name: List installed
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+        conda config --add channels conda-forge
     - name: Install dependencies
       run: |
         conda install flake8 pytest-cov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
         conda install jupyter
     - name: Install gwpopulation
       run: |
-        conda install .
+        python -m pip install .
     - name: Run pre-commit checks
       run: |
         pre-commit run --all-files --verbose --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: codespell # Spellchecker
-        args: [-L, nd]
+        args: [-L, "nd", "--skip", "*.ipynb"]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: codespell # Spellchecker
-        args: [-L, "nd", "--skip", "*.ipynb"]
+        args: [-L, "nd,hist", "--skip", "*.ipynb"]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,7 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = [".rst", ".md"]
-source_suffix = [".txt", ".ipynb", ".rst"]
+source_suffix = [".txt", ".rst"]
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
Currently, the `jupyter` examples aren't rendering properly in the online documentation, this will resolve that.

There's also a fix to allow `codespell` to run on notebooks that contain output.