### PR TITLE
Reduce top level imports

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE.md
+include requirements.txt

--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -3,7 +3,6 @@ Implemented redshift models
 """
 
 import numpy as np
-from astropy.cosmology import Planck15
 
 from ..cupy_utils import to_numpy, trapz, xp
 
@@ -14,6 +13,8 @@ class _Redshift(object):
     """
 
     def __init__(self, z_max=2.3):
+        from astropy.cosmology import Planck15
+
         self.z_max = z_max
         self.zs_ = np.linspace(1e-3, z_max, 1000)
         self.zs = xp.asarray(self.zs_)
@@ -150,10 +151,9 @@ class MadauDickinsonRedshift(_Redshift):
         return psi_of_z
 
 
-power_law_redshift = PowerLawRedshift()
-
-
 def total_four_volume(lamb, analysis_time, max_redshift=2.3):
+    from astropy.cosmology import Planck15
+
     redshifts = np.linspace(0, max_redshift, 1000)
     psi_of_z = (1 + redshifts) ** lamb
     normalization = 4 * np.pi / 1e9 * analysis_time

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ VERSION = "0.7.0"
 version_file = write_version_file(VERSION)
 long_description = get_long_description()
 
+with open("requirements.txt", "r") as ff:
+    requirements = ff.readlines()
 setup(
     name="gwpopulation",
     description="Unified population inference",
@@ -76,7 +78,7 @@ setup(
     packages=find_packages(exclude=["test", "venv", "priors"]),
     package_dir={"gwpopulation": "gwpopulation"},
     package_data={"gwpopulation": [version_file]},
-    install_requires=["future", "numpy", "scipy", "astropy", "bilby"],
+    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
- Make requirements consistent in `setup.py` and `requirements.txt`
- Remove top-level imports of `pandas`, `astropy`, `tqdm`, `scipy.stats`
- Remove the creation of the `PowerLawRedshift` instance on import