### PR TITLE
Extend dVc/dz caching in redshift models 

### DIFF
--- a/gwpopulation/models/redshift.py
+++ b/gwpopulation/models/redshift.py
@@ -20,13 +20,13 @@ class _Redshift(object):
         self.zs = xp.asarray(self.zs_)
         self.dvc_dz_ = Planck15.differential_comoving_volume(self.zs_).value * 4 * np.pi
         self.dvc_dz = xp.asarray(self.dvc_dz_)
-        self.cached_dvc_dz = None
+        self.cached_dvc_dz = {}
 
     def __call__(self, *args, **kwargs):
         raise NotImplementedError
 
     def _cache_dvc_dz(self, redshifts):
-        self.cached_dvc_dz = xp.asarray(
+        self.cached_dvc_dz[redshifts.shape] = xp.asarray(
             np.interp(to_numpy(redshifts), self.zs_, self.dvc_dz_, left=0, right=0)
         )
 
@@ -82,10 +82,10 @@ class _Redshift(object):
         psi_of_z = self.psi_of_z(redshift=dataset["redshift"], **parameters)
         differential_volume = psi_of_z / (1 + dataset["redshift"])
         try:
-            differential_volume *= self.cached_dvc_dz
-        except (TypeError, ValueError):
+            differential_volume *= self.cached_dvc_dz[dataset["redshift"].shape]
+        except KeyError:
             self._cache_dvc_dz(dataset["redshift"])
-            differential_volume *= self.cached_dvc_dz
+            differential_volume *= self.cached_dvc_dz[dataset["redshift"].shape]
         return differential_volume
 
 


### PR DESCRIPTION
added redshift model dVc/dz caching according to `dataset['redshift'].shape` instead of just a single cache element. 

This fixes the caching for calling the redshift model between PE data and injection data as mentioned in #4 -- The caching currently done in `bilby.hyper.model.Model` may also affect this behavior in some situations. Maybe a similar thing can be done there which I see has been started in this MR - https://git.ligo.org/lscsoft/bilby/-/merge_requests/871