### PR TITLE
added change to vt.py to use mu rather than marginalized pdet

### DIFF
--- a/gwpopulation/vt.py
+++ b/gwpopulation/vt.py
@@ -80,7 +80,7 @@ class ResamplingVT(_BaseVT):
             self._surveyed_hypervolume = total_four_volume(
                 lamb=0, analysis_time=self.analysis_time
             )
-            
+
     def __call__(self, parameters):
         """
         Compute the expected number of detections given a set of injections.

--- a/gwpopulation/vt.py
+++ b/gwpopulation/vt.py
@@ -80,6 +80,7 @@ class ResamplingVT(_BaseVT):
             self._surveyed_hypervolume = total_four_volume(
                 lamb=0, analysis_time=self.analysis_time
             )
+            
     def __call__(self, parameters):
         """
         Compute the expected number of detections given a set of injections.
@@ -95,11 +96,17 @@ class ResamplingVT(_BaseVT):
             The population parameters
         """
         mu, var = self.detection_efficiency(parameters)
-        if mu**2 <= 4 * self.n_events * var:
+        converged = self.check_convergence(mu, var)
+        if not converged:
             return np.inf
-        n_effective = mu**2 / var
         return mu
-                        
+
+    def check_convergence(self, mu, var):
+        if mu**2 <= 4 * self.n_events * var:
+            return False
+        else:
+            return True
+
     def vt_factor(self, parameters):
         """
         Compute the expected number of detections given a set of injections.
@@ -115,7 +122,8 @@ class ResamplingVT(_BaseVT):
             The population parameters
         """
         mu, var = self.detection_efficiency(parameters)
-        if mu**2 <= 4 * self.n_events * var:
+        converged = self.check_convergence(mu, var)
+        if not converged:
             return np.inf
         n_effective = mu**2 / var
         vt_factor = mu / np.exp((3 + self.n_events) / 2 / n_effective)

--- a/gwpopulation/vt.py
+++ b/gwpopulation/vt.py
@@ -80,8 +80,27 @@ class ResamplingVT(_BaseVT):
             self._surveyed_hypervolume = total_four_volume(
                 lamb=0, analysis_time=self.analysis_time
             )
-
     def __call__(self, parameters):
+        """
+        Compute the expected number of detections given a set of injections.
+
+        This should be implemented as in https://arxiv.org/abs/1904.10879
+
+        If n_effective < 4 * n_events we return np.inf so that the sample
+        is rejected.
+
+        Parameters
+        ----------
+        parameters: dict
+            The population parameters
+        """
+        mu, var = self.detection_efficiency(parameters)
+        if mu**2 <= 4 * self.n_events * var:
+            return np.inf
+        n_effective = mu**2 / var
+        return mu
+                        
+    def vt_factor(self, parameters):
         """
         Compute the expected number of detections given a set of injections.
 

--- a/test/example_test.py
+++ b/test/example_test.py
@@ -54,7 +54,7 @@ def test_likelihood_evaluation():
     priors = bilby.core.prior.PriorDict("priors/bbh_population.prior")
 
     likelihood.parameters.update(priors.sample())
-    assert abs(likelihood.log_likelihood_ratio() - 0.1319280773148961) < 0.01
+    assert abs(likelihood.log_likelihood_ratio() - 0.20244516618071628) < 0.01
 
 
 def test_prior_files_load():

--- a/test/example_test.py
+++ b/test/example_test.py
@@ -54,7 +54,7 @@ def test_likelihood_evaluation():
     priors = bilby.core.prior.PriorDict("priors/bbh_population.prior")
 
     likelihood.parameters.update(priors.sample())
-    assert abs(likelihood.log_likelihood_ratio() - 0.20244516618071628) < 0.01
+    assert abs(likelihood.log_likelihood_ratio() - 0.06141098844907589) < 0.01
 
 
 def test_prior_files_load():

--- a/test/vt_test.py
+++ b/test/vt_test.py
@@ -56,14 +56,14 @@ class TestResamplingVT(unittest.TestCase):
         self.vt = vt.ResamplingVT(data=self.data, model=model, n_events=0)
 
     def test_marginalized_vt_correct(self):
-        self.assertEqual(self.vt_factor(dict()), 0.38289325179141254)
+        self.assertEqual(self.vt.vt_factor(dict()), 0.38289325179141254)
 
     def test_vt_correct(self):
         self.assertEqual(self.vt(dict())[0], 0.38289403358409585)
 
     def test_returns_inf_when_n_effective_too_small(self):
         self.vt.n_events = xp.inf
-        self.assertEqual(self.vt(dict()), xp.inf)
+        self.assertEqual(self.vt.vt_factor(dict()), xp.inf)
 
     def test_observed_volume_with_no_redshift_model(self):
         self.assertEqual(

--- a/test/vt_test.py
+++ b/test/vt_test.py
@@ -56,10 +56,10 @@ class TestResamplingVT(unittest.TestCase):
         self.vt = vt.ResamplingVT(data=self.data, model=model, n_events=0)
 
     def test_marginalized_vt_correct(self):
-        self.assertEqual(self.vt(dict()), 0.38289325179141254)
+        self.assertEqual(self.vt_factor(dict()), 0.38289325179141254)
 
-    def test_marginalized_vt_correct(self):
-        self.assertEqual(self.vt(dict()), 0.38289403358409585)
+    def test_vt_correct(self):
+        self.assertEqual(self.vt(dict())[0], 0.38289403358409585)
 
     def test_returns_inf_when_n_effective_too_small(self):
         self.vt.n_events = xp.inf

--- a/test/vt_test.py
+++ b/test/vt_test.py
@@ -55,8 +55,11 @@ class TestResamplingVT(unittest.TestCase):
         self.data = dict(a=xp.linspace(0, 1, 1000), prior=xp.ones(1000), vt=2)
         self.vt = vt.ResamplingVT(data=self.data, model=model, n_events=0)
 
-    def test_vt_correct(self):
+    def test_marginalized_vt_correct(self):
         self.assertEqual(self.vt(dict()), 0.38289325179141254)
+
+    def test_marginalized_vt_correct(self):
+        self.assertEqual(self.vt(dict()), 0.38289403358409585)
 
     def test_returns_inf_when_n_effective_too_small(self):
         self.vt.n_events = xp.inf


### PR DESCRIPTION
This PR changes the default call of the ResamplingVT to use the estimator of the Monte Carlo rather than the marginalized pdet from [Farr 2019](https://arxiv.org/abs/1904.10879). Justification: see top of pg 14 on [Essick & Farr](https://arxiv.org/pdf/2204.00461.pdf) for example.