### PR TITLE
Plugin backend usage

### DIFF
--- a/gwpopulation/__init__.py
+++ b/gwpopulation/__init__.py
@@ -2,28 +2,22 @@
 GWPopulation
 ============
 
-A collection of code for doing population inference.
-
-All of this code will run on either CPUs or GPUs using cupy for GPU
-acceleration.
+A collection of code for doing population inference with the 
+gravitational-wave transient catalogue.
 
 This includes:
   - commonly used likelihood functions in the Bilby framework.
   - population models for gravitational-wave sources.
   - selection functions for gravitational-wave sources.
 
-The code is hosted at `<www.github.com/ColmTalbot/gwpopulation>`_.
+:code:`GWPopulation` supports multiple numpy-like backends, including
+:code:`numpy`, :code:`jax`, and :code:`cupy`. The :code:`jax` and
+:code:`cupy` backends allow for GPU acceleration.
+
+The code is hosted at `<www.github.com/ColmTalbot/gwpopulation>`_ and
+available via :code:`conda-forge` and :code:`pypi`.
 """
 from . import conversions, hyperpe, models, utils, vt
-from .backend import SUPPORTED_BACKENDS, disable_cupy, enable_cupy, set_backend
-from .hyperpe import RateLikelihood
+from .backend import SUPPORTED_BACKENDS, set_backend
 
-try:
-    from ._version import __version__
-except ModuleNotFoundError:  # development mode
-    __version__ = "unknown"
-
-try:
-    set_backend("cupy")
-except ImportError:
-    set_backend("numpy")
+from ._version import __version__

--- a/gwpopulation/__init__.py
+++ b/gwpopulation/__init__.py
@@ -2,7 +2,7 @@
 GWPopulation
 ============
 
-A collection of code for doing population inference with the 
+A collection of code for doing population inference with the
 gravitational-wave transient catalogue.
 
 This includes:
@@ -18,6 +18,5 @@ The code is hosted at `<www.github.com/ColmTalbot/gwpopulation>`_ and
 available via :code:`conda-forge` and :code:`pypi`.
 """
 from . import conversions, hyperpe, models, utils, vt
-from .backend import SUPPORTED_BACKENDS, set_backend
-
 from ._version import __version__
+from .backend import SUPPORTED_BACKENDS, set_backend

--- a/gwpopulation/backend.py
+++ b/gwpopulation/backend.py
@@ -8,6 +8,7 @@ _scipy_module = dict(numpy="scipy", cupy="cupyx.scipy", jax="jax.scipy")
 
 def modules_to_update():
     import sys
+
     if sys.version_info < (3, 10):
         from importlib_metadata import entry_points
     else:
@@ -21,9 +22,13 @@ def modules_to_update():
         ".utils",
         ".vt",
     ]
-    all_with_xp.extend([module.value for module in entry_points(group="gwpopulation.xp")])
+    all_with_xp.extend(
+        [module.value for module in entry_points(group="gwpopulation.xp")]
+    )
     all_with_scs = [".models.mass", ".utils"]
-    all_with_scs.extend([module.value for module in entry_points(group="gwpopulation.scs")])
+    all_with_scs.extend(
+        [module.value for module in entry_points(group="gwpopulation.scs")]
+    )
     return all_with_xp, all_with_scs
 
 
@@ -72,9 +77,9 @@ def _load_numpy_and_scipy(backend):
 
 def _set_in_module(module, name, value):
     if module.startswith("."):
-        package="gwpopulation"
+        package = "gwpopulation"
     else:
-        package=None
+        package = None
     setattr(import_module(module, package=package), name, value)
 
 
@@ -87,7 +92,7 @@ def set_backend(backend="numpy"):
     elif backend == __backend__:
         return
 
-    xp, scs = _load_numpy_and_scipy(backend)       
+    xp, scs = _load_numpy_and_scipy(backend)
 
     __backend__ = backend
     all_with_xp, all_with_scs = modules_to_update()

--- a/gwpopulation/backend.py
+++ b/gwpopulation/backend.py
@@ -1,19 +1,30 @@
 from importlib import import_module
 
-__all_with_xp = [
-    "hyperpe",
-    "models.interped",
-    "models.mass",
-    "models.redshift",
-    "models.spin",
-    "utils",
-    "vt",
-]
-__all_with_scs = ["models.mass", "utils"]
 __backend__ = ""
 SUPPORTED_BACKENDS = ["numpy", "cupy", "jax"]
 _np_module = dict(numpy="numpy", cupy="cupy", jax="jax.numpy")
 _scipy_module = dict(numpy="scipy", cupy="cupyx.scipy", jax="jax.scipy")
+
+
+def modules_to_update():
+    import sys
+    if sys.version_info < (3, 10):
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
+    all_with_xp = [
+        ".hyperpe",
+        ".models.interped",
+        ".models.mass",
+        ".models.redshift",
+        ".models.spin",
+        ".utils",
+        ".vt",
+    ]
+    all_with_xp.extend([module.value for module in entry_points(group="gwpopulation.xp")])
+    all_with_scs = [".models.mass", ".utils"]
+    all_with_scs.extend([module.value for module in entry_points(group="gwpopulation.scs")])
+    return all_with_xp, all_with_scs
 
 
 def disable_cupy():
@@ -44,15 +55,7 @@ def _configure_jax(xp):
     xp.trapz = trapezoid
 
 
-def set_backend(backend="numpy"):
-    global __backend__
-    if backend not in SUPPORTED_BACKENDS:
-        raise ValueError(
-            f"Backend {backend} not supported, should be in {', '.join(SUPPORTED_BACKENDS)}"
-        )
-    elif backend == __backend__:
-        return
-
+def _load_numpy_and_scipy(backend):
     try:
         xp = import_module(_np_module[backend])
         scs = import_module(_scipy_module[backend]).special
@@ -64,8 +67,31 @@ def set_backend(backend="numpy"):
     if backend == "jax":
         _configure_jax(xp)
 
-    for module in __all_with_xp:
-        __backend__ = backend
-        import_module(f".{module}", package="gwpopulation").xp = xp
-    for module in __all_with_scs:
-        import_module(f".{module}", package="gwpopulation").scs = scs
+    return xp, scs
+
+
+def _set_in_module(module, name, value):
+    if module.startswith("."):
+        package="gwpopulation"
+    else:
+        package=None
+    setattr(import_module(module, package=package), name, value)
+
+
+def set_backend(backend="numpy"):
+    global __backend__
+    if backend not in SUPPORTED_BACKENDS:
+        raise ValueError(
+            f"Backend {backend} not supported, should be in {', '.join(SUPPORTED_BACKENDS)}"
+        )
+    elif backend == __backend__:
+        return
+
+    xp, scs = _load_numpy_and_scipy(backend)       
+
+    __backend__ = backend
+    all_with_xp, all_with_scs = modules_to_update()
+    for module in all_with_xp:
+        _set_in_module(module, "xp", xp)
+    for module in all_with_scs:
+        _set_in_module(module, "scs", scs)

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -172,7 +172,9 @@ class HyperparameterLikelihood(Likelihood):
         selection, variance = self._selection_function_with_uncertainty()
         total_selection = -self.n_posteriors * xp.log(selection)
         if return_uncertainty:
-            total_variance = self.n_posteriors**2 * xp.divide(variance, selection**2)
+            total_variance = self.n_posteriors**2 * xp.divide(
+                variance, selection**2
+            )
             return total_selection, total_variance
         else:
             return total_selection

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -172,7 +172,7 @@ class HyperparameterLikelihood(Likelihood):
         selection, variance = self._selection_function_with_uncertainty()
         total_selection = -self.n_posteriors * xp.log(selection)
         if return_uncertainty:
-            total_variance = self.n_posteriors**2 * variance / selection**2
+            total_variance = self.n_posteriors**2 * xp.divide(variance, selection**2)
             return total_selection, total_variance
         else:
             return total_selection

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -548,12 +548,6 @@ class BaseSmoothedMassDistribution(object):
             dataset["mass_1"], mmin=mmin, mmax=self.mmax, delta_m=delta_m
         )
         norm = self.norm_p_m1(delta_m=delta_m, **kwargs)
-        print(
-            norm,
-            self.smoothing(
-                dataset["mass_1"], mmin=mmin, mmax=self.mmax, delta_m=delta_m
-            ),
-        )
         return p_m / norm
 
     def norm_p_m1(self, delta_m, **kwargs):

--- a/test/backend_test.py
+++ b/test/backend_test.py
@@ -26,14 +26,14 @@ def test_set_backend(backend):
 def test_enable_cupy_deprecated():
     with pytest.deprecated_call():
         try:
-            gwpopulation.enable_cupy()
+            gwpopulation.backend.enable_cupy()
         except ImportError:
             pass
 
 
 def test_disable_cupy_deprecated():
     with pytest.deprecated_call():
-        gwpopulation.disable_cupy()
+        gwpopulation.backend.disable_cupy()
 
 
 def test_import_error_caught_for_mangled_install():


### PR DESCRIPTION
This PR allows downstream packages to define a `gwpopulation.xp` or `gwpopulation.scs` plugin that will automatically propagate changes to the gwpopulation backend, e.g., for gwpopulation_pipe.

I also fixed a bug that appeared with numpy/cupy division.