### PR TITLE
DEV: add regularization option for spline interpolated models

### DIFF
--- a/gwpopulation/models/interped.py
+++ b/gwpopulation/models/interped.py
@@ -7,17 +7,20 @@ from ..utils import to_numpy
 xp = np
 
 
-def _setup_interpolant(nodes, values, kind="cubic", backend=xp):
+def _setup_interpolant(nodes, values, kind="cubic", backend=None):
     """
     Cache the information necessary for linear interpolation of the mass
     ratio normalisation
     """
     from cached_interpolate import RegularCachingInterpolant as CachingInterpolant
 
+    if backend is None:
+        backend = xp
+
     nodes = to_numpy(nodes)
     interpolant = CachingInterpolant(nodes, nodes, kind=kind, backend=backend)
-    interpolant.conversion = xp.asarray(interpolant.conversion)
-    interpolant = partial(interpolant, xp.asarray(values))
+    interpolant.conversion = backend.array(interpolant.conversion)
+    interpolant = partial(interpolant, backend.array(values))
     return interpolant
 
 

--- a/gwpopulation/models/interped.py
+++ b/gwpopulation/models/interped.py
@@ -45,7 +45,14 @@ class InterpolatedNoBaseModelIdentical:
     """
 
     def __init__(
-        self, parameters, minimum, maximum, nodes=10, kind="cubic", log_nodes=False, regularize=False
+        self,
+        parameters,
+        minimum,
+        maximum,
+        nodes=10,
+        kind="cubic",
+        log_nodes=False,
+        regularize=False,
     ):
         """ """
         self.nodes = nodes
@@ -88,7 +95,9 @@ class InterpolatedNoBaseModelIdentical:
 
     def p_x_unnormed(self, dataset, parameter, x_splines, f_splines, **kwargs):
         if self.regularize:
-            f_splines = f_splines * kwargs[f"rms{self.base}"] / xp.sum(f_splines**2)**0.5
+            f_splines = (
+                f_splines * kwargs[f"rms{self.base}"] / xp.sum(f_splines**2) ** 0.5
+            )
 
         if self._norm_spline is None:
             self.setup_interpolant(x_splines, dataset)

--- a/gwpopulation/models/interped.py
+++ b/gwpopulation/models/interped.py
@@ -135,10 +135,8 @@ class InterpolatedNoBaseModelIdentical:
             The positions of the spline nodes
         """
         f_splines = xp.array([kwargs[key] for key in self.fkeys])
-        print(f_splines, xp.mean(f_splines**2) ** 0.5)
         if self.regularize:
             f_splines *= kwargs[f"rms{self.base}"] / xp.mean(f_splines**2) ** 0.5
-        print(f_splines, xp.mean(f_splines**2) ** 0.5)
         x_splines = xp.array([kwargs[key] for key in self.xkeys])
         return f_splines, x_splines
 

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -846,7 +846,7 @@ class InterpolatedPowerlaw(
         mmin=2,
         mmax=100,
         normalization_shape=(1000, 500),
-        regularize=True,
+        regularize=False,
     ):
         """
         Parameters

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -892,8 +892,7 @@ class InterpolatedPowerlaw(
 
     def p_m1(self, dataset, **kwargs):
 
-        f_splines = xp.array([kwargs[key] for key in self.fkeys])
-        m_splines = xp.array([kwargs[key] for key in self.xkeys])
+        f_splines, m_splines = self.extract_spline_points(kwargs)
 
         mmin = kwargs.get("mmin", self.mmin)
         delta_m = kwargs.pop("delta_m", 0)

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -840,7 +840,13 @@ class InterpolatedPowerlaw(
     primary_model = power_law_mass
 
     def __init__(
-        self, nodes=10, kind="cubic", mmin=2, mmax=100, normalization_shape=(1000, 500), regularize=True
+        self,
+        nodes=10,
+        kind="cubic",
+        mmin=2,
+        mmax=100,
+        normalization_shape=(1000, 500),
+        regularize=True,
     ):
         """
         Parameters

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -840,7 +840,7 @@ class InterpolatedPowerlaw(
     primary_model = power_law_mass
 
     def __init__(
-        self, nodes=10, kind="cubic", mmin=2, mmax=100, normalization_shape=(1000, 500)
+        self, nodes=10, kind="cubic", mmin=2, mmax=100, normalization_shape=(1000, 500), regularize=True
     ):
         """
         Parameters
@@ -855,6 +855,9 @@ class InterpolatedPowerlaw(
             The maximum mass considered for numerical normalization, default=100.
         normalization_shape: tuple
             Shape of the grid used for numerical normalization, default=(1000, 500).
+        regularize: bool
+            Whether to regularize the spline node values to have root-mean-square value
+            :code:`rms{name}`, default=False
         """
         BaseSmoothedMassDistribution.__init__(
             self,
@@ -870,6 +873,7 @@ class InterpolatedPowerlaw(
             nodes=nodes,
             kind=kind,
             log_nodes=True,
+            regularize=regularize,
         )
         self._xs = self.m1s
 

--- a/gwpopulation/models/spin.py
+++ b/gwpopulation/models/spin.py
@@ -281,7 +281,7 @@ class GaussianChiEffChiP(object):
 
 
 class SplineSpinMagnitudeIdentical(InterpolatedNoBaseModelIdentical):
-    def __init__(self, minimum=0, maximum=1, nodes=5, kind="cubic"):
+    def __init__(self, minimum=0, maximum=1, nodes=5, kind="cubic", regularize=False):
 
         super(SplineSpinMagnitudeIdentical, self).__init__(
             parameters=["a_1", "a_2"],
@@ -289,11 +289,12 @@ class SplineSpinMagnitudeIdentical(InterpolatedNoBaseModelIdentical):
             maximum=maximum,
             nodes=nodes,
             kind=kind,
+            regularize=regularize,
         )
 
 
 class SplineSpinTiltIdentical(InterpolatedNoBaseModelIdentical):
-    def __init__(self, minimum=-1, maximum=1, nodes=5, kind="cubic"):
+    def __init__(self, minimum=-1, maximum=1, nodes=5, kind="cubic", regularize=False):
 
         super(SplineSpinTiltIdentical, self).__init__(
             parameters=["cos_tilt_1", "cos_tilt_2"],
@@ -301,4 +302,5 @@ class SplineSpinTiltIdentical(InterpolatedNoBaseModelIdentical):
             maximum=maximum,
             nodes=nodes,
             kind=kind,
+            regularize=regularize,
         )

--- a/test/interped_test.py
+++ b/test/interped_test.py
@@ -1,0 +1,43 @@
+import functools
+import importlib
+
+import numpy as np
+import pytest
+
+from gwpopulation.backend import _np_module, set_backend
+from gwpopulation.models.interped import (
+    InterpolatedNoBaseModelIdentical,
+    _setup_interpolant,
+)
+
+from . import TEST_BACKENDS
+
+
+def test_regularize_option_adds_rms_variable():
+    for regularize in [True, False]:
+        model = InterpolatedNoBaseModelIdentical(
+            parameters=["a_1"], minimum=0, maximum=1, regularize=regularize
+        )
+        assert ("rmsa" in model.variable_names) is regularize
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+def test_setup_interpolant_obeys_backend(backend):
+    xp = importlib.import_module(_np_module[backend])
+    interpolant = _setup_interpolant(
+        nodes=np.linspace(0, 1, 5),
+        values=np.linspace(0, 1, 1000),
+        backend=xp,
+    )
+    assert isinstance(interpolant.func.conversion, xp.ndarray)
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
+def test_setup_interpolant_obeys_backend_implicit(backend):
+    xp = importlib.import_module(_np_module[backend])
+    set_backend(backend)
+    interpolant = _setup_interpolant(
+        nodes=np.linspace(0, 1, 5),
+        values=np.linspace(0, 1, 1000),
+    )
+    assert isinstance(interpolant.func.conversion, xp.ndarray)

--- a/test/interped_test.py
+++ b/test/interped_test.py
@@ -13,6 +13,23 @@ from gwpopulation.models.interped import (
 from . import TEST_BACKENDS
 
 
+@pytest.mark.parametrize("regularize", [True, False])
+def test_regularization_works(regularize):
+    model = InterpolatedNoBaseModelIdentical(
+        parameters=["a_1"], minimum=0, maximum=1, regularize=regularize
+    )
+    parameters = {key: value for key, value in zip(model.xkeys, np.linspace(0, 1, 10))}
+    parameters.update({key: 1.0 for key in model.fkeys})
+    if regularize:
+        parameters["rmsa"] = 0.1
+    values = model.extract_spline_points(parameters)[0]
+    if regularize:
+        expected = 0.1
+    else:
+        expected = 1
+    assert abs((values**2).mean() ** 0.5 - expected) < 1e-10
+
+
 def test_regularize_option_adds_rms_variable():
     for regularize in [True, False]:
         model = InterpolatedNoBaseModelIdentical(


### PR DESCRIPTION
This PR adds an option to provide an explicit regularization for the exponentiated spline models.
This defines one new parameter per mode `rms{name}`.
Each of the `f{name}` parameters are scaled such that the root-mean-square value of `f{name}` is `rms{name}`.