### PR TITLE
fix cupy.where error for mass model

### DIFF
--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -580,7 +580,7 @@ class BaseSmoothedMassDistribution:
         p_m = self.__class__.primary_model(self.m1s, **kwargs)
         p_m *= self.smoothing(self.m1s, mmin=mmin, mmax=self.mmax, delta_m=delta_m)
 
-        norm = xp.where(xp.array(delta_m > 0), xp.trapz(p_m, self.m1s), 1)
+        norm = xp.where(xp.array(delta_m) > 0, xp.trapz(p_m, self.m1s), 1)
         return norm
 
     def p_q(self, dataset, beta, mmin, delta_m):
@@ -606,7 +606,7 @@ class BaseSmoothedMassDistribution:
             self.m1s_grid * self.qs_grid, mmin=mmin, mmax=self.m1s_grid, delta_m=delta_m
         )
         norms = xp.where(
-            delta_m > 0,
+            xp.array(delta_m) > 0,
             xp.nan_to_num(xp.trapz(p_q, self.qs, axis=0)),
             xp.ones(self.m1s.shape),
         )

--- a/gwpopulation/models/mass.py
+++ b/gwpopulation/models/mass.py
@@ -580,7 +580,7 @@ class BaseSmoothedMassDistribution:
         p_m = self.__class__.primary_model(self.m1s, **kwargs)
         p_m *= self.smoothing(self.m1s, mmin=mmin, mmax=self.mmax, delta_m=delta_m)
 
-        norm = xp.where(delta_m > 0, xp.trapz(p_m, self.m1s), 1)
+        norm = xp.where(xp.array(delta_m > 0), xp.trapz(p_m, self.m1s), 1)
         return norm
 
     def p_q(self, dataset, beta, mmin, delta_m):


### PR DESCRIPTION
There is slight difference between numpy.where and cupy.where. For cupy.where, it seems a 'bool' object is not allowed as condition.
Update xp.where(delta_m > 0, xxx, yyy) in mass model by xp.where(xp.array(delta_m) > 0, xxx, yyy).
<img width="903" alt="Screenshot 2024-01-31 at 11 38 33 am" src="https://github.com/ColmTalbot/gwpopulation/assets/101712107/6e5e4f1a-fe22-4b0b-9a7b-366c8312d365">