### PR TITLE
ENH: make truncnorm more robust

### DIFF
--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -163,7 +163,7 @@ def truncnorm(xx, mu, sigma, high, low):
     zz = (xx - mu) / sigma
     aa = (low - mu) / sigma
     bb = (high - mu) / sigma
-    log_pdf = - zz**2 / 2.0 - xp.log(2.0 * xp.pi) / 2.0 - xp.log(sigma)
+    log_pdf = -(zz**2) / 2.0 - xp.log(2.0 * xp.pi) / 2.0 - xp.log(sigma)
     # cf https://github.com/scipy/scipy/blob/v1.15.1/scipy/stats/_continuous_distns.py#L10189
     log_norm = xp.select(
         [bb <= 0, aa > 0],

--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -160,14 +160,21 @@ def truncnorm(xx, mu, sigma, high, low):
         The distribution evaluated at `xx`
 
     """
-    norm = 2**0.5 / xp.pi**0.5 / sigma
-    norm /= scs.erf((high - mu) / 2**0.5 / sigma) + scs.erf(
-        (mu - low) / 2**0.5 / sigma
+    zz = (xx - mu) / sigma
+    aa = (low - mu) / sigma
+    bb = (high - mu) / sigma
+    log_pdf = - zz**2 / 2.0 - xp.log(2.0 * xp.pi) / 2.0 - xp.log(sigma)
+    # cf https://github.com/scipy/scipy/blob/v1.15.1/scipy/stats/_continuous_distns.py#L10189
+    log_norm = xp.select(
+        [bb <= 0, aa > 0],
+        [
+            xp.logaddexp(scs.log_ndtr(bb), scs.log_ndtr(aa) + np.pi * 1j).real,
+            -xp.logaddexp(scs.log_ndtr(-aa), scs.log_ndtr(-bb) + np.pi * 1j).real,
+        ],
+        xp.log1p(-scs.log_ndtr(aa) - scs.log_ndtr(-bb)),
     )
-    prob = xp.exp(-xp.power(xx - mu, 2) / (2 * sigma**2))
-    prob *= norm
-    prob *= (xx <= high) & (xx >= low)
-    return prob
+    log_pdf -= log_norm
+    return xp.exp(log_pdf) * (xx >= low) * (xx <= high)
 
 
 def unnormalized_2d_gaussian(xx, yy, mu_x, mu_y, sigma_x, sigma_y, covariance):

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -112,6 +112,26 @@ def test_truncnorm_sigma_below_zero_raises_value_error():
 
 
 @pytest.mark.parametrize("backend", TEST_BACKENDS)
+def test_truncnorm_matches_scipy(backend):
+    from scipy.stats import truncnorm
+
+    gwpopulation.set_backend(backend)
+    xp = gwpopulation.utils.xp
+    xx = xp.linspace(-2, 2, 1000)
+    for ii in range(N_TEST):
+        mu = np.random.uniform(-10, 10)
+        sigma = np.random.uniform(0, 5)
+        low, high = np.sort(np.random.uniform(-10, 10, 2))
+        gwpop_vals = utils.to_numpy(
+            utils.truncnorm(xx, mu=mu, sigma=sigma, low=low, high=high)
+        )
+        scipy_vals = truncnorm(
+            loc=mu, scale=sigma, a=(low - mu) / sigma, b=(high - mu) / sigma
+        ).pdf(utils.to_numpy(xx))
+        assert max(abs(gwpop_vals - scipy_vals)) < 1e-3
+
+
+@pytest.mark.parametrize("backend", TEST_BACKENDS)
 def test_matches_scipy(backend):
     gwpopulation.set_backend(backend)
     xp = gwpopulation.utils.xp


### PR DESCRIPTION
I had reports of bad normalization for truncnorm when the mean was many sigma away from the support. The new method more closely aligns with scipy.