### PR TITLE
Add flexibility to gaussian spin tilt

### DIFF
--- a/gwpopulation/models/spin.py
+++ b/gwpopulation/models/spin.py
@@ -92,7 +92,7 @@ def independent_spin_magnitude_beta(
     return prior
 
 
-def iid_spin_orientation_gaussian_isotropic(dataset, xi_spin, sigma_spin):
+def iid_spin_orientation_gaussian_isotropic(dataset, xi_spin, sigma_spin, mu_spin=1):
     r"""
     A mixture model of spin orientations with isotropic and normally
     distributed components. The distribution of primary and secondary spin
@@ -113,16 +113,20 @@ def iid_spin_orientation_gaussian_isotropic(dataset, xi_spin, sigma_spin):
     dataset: dict
         Dictionary of numpy arrays for 'cos_tilt_1' and 'cos_tilt_2'.
     xi_spin: float
-        Fraction of black holes in preferentially aligned component (:math:`\xi`).
+        Fraction of black holes in gaussian component (:math:`\xi`).
     sigma_spin: float
-        Width of preferentially aligned component.
+        Width of gaussian component.
+    mu_spin: float
+        Mean of the gaussian component (default: cos_tilt = 1).
     """
     return independent_spin_orientation_gaussian_isotropic(
-        dataset, xi_spin, sigma_spin, sigma_spin
+        dataset, xi_spin, sigma_spin, sigma_spin, mu_spin, mu_spin
     )
 
 
-def independent_spin_orientation_gaussian_isotropic(dataset, xi_spin, sigma_1, sigma_2):
+def independent_spin_orientation_gaussian_isotropic(
+    dataset, xi_spin, sigma_1, sigma_2, mu_1=1, mu_2=1
+):
     r"""
     A mixture model of spin orientations with isotropic and normally
     distributed components.
@@ -142,17 +146,23 @@ def independent_spin_orientation_gaussian_isotropic(dataset, xi_spin, sigma_1, s
     dataset: dict
         Dictionary of numpy arrays for 'cos_tilt_1' and 'cos_tilt_2'.
     xi_spin: float
-        Fraction of black holes in preferentially aligned component (:math:`\xi`).
+        Fraction of black holes in gaussian component (:math:`\xi`).
+    mu_1: float
+        Mean of the gaussian component for the more
+        massive black hole (:math:`\mu_1`).
+    mu_2: float
+        Mean of the gaussian component for the less
+        massive black hole (:math:`\mu_2`).
     sigma_1: float
-        Width of preferentially aligned component for the more
+        Width of the gaussian component for the more
         massive black hole (:math:`\sigma_1`).
     sigma_2: float
-        Width of preferentially aligned component for the less
+        Width of the gaussian component for the less
         massive black hole (:math:`\sigma_2`).
     """
     prior = (1 - xi_spin) / 4 + xi_spin * truncnorm(
-        dataset["cos_tilt_1"], 1, sigma_1, 1, -1
-    ) * truncnorm(dataset["cos_tilt_2"], 1, sigma_2, 1, -1)
+        dataset["cos_tilt_1"], mu_1, sigma_1, 1, -1
+    ) * truncnorm(dataset["cos_tilt_2"], mu_2, sigma_2, 1, -1)
     return prior
 
 

--- a/priors/bbh_population.prior
+++ b/priors/bbh_population.prior
@@ -1,6 +1,8 @@
 xi_spin = Uniform(minimum=0, maximum=1, name='xi_spin', latex_label='$\\xi$')
 amax_1 = Uniform(minimum=0, maximum=1, name='amax_1', latex_label='$a_{\\max 1}$')
 amax_2 = Uniform(minimum=0, maximum=1, name='amax_2', latex_label='$a_{\\max 2}$')
+mu_1 = 1.0
+mu_2 = 1.0
 sigma_1 = Uniform(minimum=1e-2, maximum=4e0, name='sigma_1', latex_label='$\\sigma_1$')
 sigma_2 = Uniform(minimum=1e-2, maximum=4e0, name='sigma_2', latex_label='$\\sigma_2$')
 alpha_chi_1 = Uniform(minimum=1, maximum=5, name='alpha_1', latex_label='$\\alpha_1$')

--- a/priors/bbh_population.prior
+++ b/priors/bbh_population.prior
@@ -1,8 +1,8 @@
 xi_spin = Uniform(minimum=0, maximum=1, name='xi_spin', latex_label='$\\xi$')
 amax_1 = Uniform(minimum=0, maximum=1, name='amax_1', latex_label='$a_{\\max 1}$')
 amax_2 = Uniform(minimum=0, maximum=1, name='amax_2', latex_label='$a_{\\max 2}$')
-mu_1 = 1.0
-mu_2 = 1.0
+mu_1 = 1
+mu_2 = 1
 sigma_1 = Uniform(minimum=1e-2, maximum=4e0, name='sigma_1', latex_label='$\\sigma_1$')
 sigma_2 = Uniform(minimum=1e-2, maximum=4e0, name='sigma_2', latex_label='$\\sigma_2$')
 alpha_chi_1 = Uniform(minimum=1, maximum=5, name='alpha_1', latex_label='$\\alpha_1$')

--- a/priors/spin.prior
+++ b/priors/spin.prior
@@ -1,6 +1,8 @@
 xi_spin = Uniform(minimum=0, maximum=1, name='xi_spin', latex_label='$\\xi$')
 amax_1 = Uniform(minimum=0, maximum=1, name='amax_1', latex_label='$a_{\\max 1}$')
 amax_2 = Uniform(minimum=0, maximum=1, name='amax_2', latex_label='$a_{\\max 2}$')
+mu_1 = 1.0
+mu_2 = 1.0
 sigma_1 = Uniform(minimum=1e-2, maximum=4e0, name='sigma_1', latex_label='$\\sigma_1$')
 sigma_2 = Uniform(minimum=1e-2, maximum=4e0, name='sigma_2', latex_label='$\\sigma_2$')
 alpha_1 = Uniform(minimum=1, maximum=5, name='alpha_1', latex_label='$\\alpha_1$')

--- a/test/example_test.py
+++ b/test/example_test.py
@@ -67,12 +67,12 @@ def _template_likelihod_evaluation(backend, jit):
     )
 
     priors = bilby.core.prior.PriorDict("priors/bbh_population.prior")
-
-    likelihood.parameters.update(priors.sample())
-    assert abs(likelihood.log_likelihood_ratio() + 1.810695) < 0.01
+    prior_sample = priors.sample()
+    likelihood.parameters.update(prior_sample)
+    assert abs(likelihood.log_likelihood_ratio() + 7.037596674351107) < 0.01
     if jit:
         likelihood = JittedLikelihood(likelihood)
-    assert abs(likelihood.log_likelihood_ratio() + 1.810695) < 0.01
+    assert abs(likelihood.log_likelihood_ratio() + 7.037596674351107) < 0.01
     likelihood.posterior_predictive_resample(pd.DataFrame(priors.sample(5)))
 
 


### PR DESCRIPTION
This PR allows the user to specify the mean of the Gaussian component of the spin tilt model in `iid_spin_orientation_gaussian_isotropic` and `independent_spin_orientation_gaussian_isotropic`. Defaults to the old model with `mu_spin = 1`. Docstrings are updated to reflect the change. 