### PR TITLE
BUG: fix bugs in truncnorm for cupy

### DIFF
--- a/gwpopulation/utils.py
+++ b/gwpopulation/utils.py
@@ -164,9 +164,9 @@ def truncnorm(xx, mu, sigma, high, low):
     def logsubexp(log_p, log_q):
         return log_p + xp.log(1 - xp.exp(log_q - log_p))
 
-    zz = (xx - mu) / sigma
-    aa = (low - mu) / sigma
-    bb = (high - mu) / sigma
+    zz = xp.array(xx - mu) / sigma
+    aa = xp.array(low - mu) / sigma
+    bb = xp.array(high - mu) / sigma
     log_pdf = -(zz**2) / 2.0 - np.log(2.0 * np.pi) / 2.0 - xp.log(sigma)
 
     # cf https://github.com/scipy/scipy/blob/v1.15.1/scipy/stats/_continuous_distns.py#L10189
@@ -180,7 +180,7 @@ def truncnorm(xx, mu, sigma, high, low):
         xp.nan,
     )
     log_pdf -= log_norm
-    return xp.exp(log_pdf) * (xx >= low) * (xx <= high)
+    return xp.nan_to_num(xp.exp(log_pdf)) * (xx >= low) * (xx <= high)
 
 
 def unnormalized_2d_gaussian(xx, yy, mu_x, mu_y, sigma_x, sigma_y, covariance):


### PR DESCRIPTION
The previous fix #118 didn't entirely resolve the issue as the conditional branches cannot be a Python scalar! This one has been tested using cupy.