### PR TITLE
FEAT: allow use of different numbers of samples per event

### DIFF
--- a/gwpopulation/experimental/numpyro.py
+++ b/gwpopulation/experimental/numpyro.py
@@ -43,8 +43,8 @@ def gwpopulation_likelihood_model(
         likelihood.hyper_prior.prob(likelihood.data, **parameters)
         / likelihood.sampling_prior
     )
-    expectations = jnp.mean(weights, axis=-1)
-    square_expectations = jnp.mean(weights**2, axis=-1)
+    expectations = likelihood._weight_expectation(weights)
+    square_expectations = likelihood._weight_expectation(weights**2)
     variances = deterministic(
         "variances",
         (square_expectations - expectations**2)

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -78,6 +78,7 @@ class HyperparameterLikelihood(Likelihood):
         selection_function=lambda args: 1,
         conversion_function=lambda args: (args, None),
         maximum_uncertainty=xp.inf,
+        require_equal_samples=False,
     ):
         """
         Parameters
@@ -105,10 +106,16 @@ class HyperparameterLikelihood(Likelihood):
             The maximum allowed uncertainty in the natural log likelihood.
             If the uncertainty is larger than this value a log likelihood of
             -inf will be returned. Default = inf
+        require_equal_samples: bool
+            Whether to require and equal number of samples per posterior.
+            Set to :code:`True` for backward compatibility.
         """
 
         self.samples_per_posterior = max_samples
-        self.data = self.resample_posteriors(posteriors, max_samples=max_samples)
+        self.equal_samples = require_equal_samples
+        self.data, self.transitions = self.resample_posteriors(
+            posteriors, max_samples=max_samples
+        )
 
         if isinstance(hyper_prior, types.FunctionType):
             hyper_prior = Model([hyper_prior])
@@ -195,15 +202,26 @@ class HyperparameterLikelihood(Likelihood):
         self, parameters, *, return_uncertainty=True
     ):
         weights = self.hyper_prior.prob(self.data, **parameters) / self.sampling_prior
-        expectation = xp.mean(weights, axis=-1)
+        expectation = self._weight_expectation(weights)
         if return_uncertainty:
-            square_expectation = xp.mean(weights**2, axis=-1)
+            square_expectation = self._weight_expectation(weights)
             variance = (square_expectation - expectation**2) / (
                 self.samples_per_posterior * expectation**2
             )
             return xp.log(expectation), variance
         else:
             return xp.log(expectation)
+
+    def _weight_expectation(self, weights):
+        if self.equal_samples:
+            expectation = xp.mean(weights, axis=-1)
+        else:
+            cumulative = xp.concat([xp.zeros(1), xp.cumsum(weights)])
+            expectation = (
+                cumulative[self.transitions[1:]]
+                - cumulative[self.transitions[:-1]]
+            ) / self.samples_per_posterior
+        return expectation
 
     def _get_selection_factor(self, parameters, *, return_uncertainty=True):
         selection, variance = self._selection_function_with_uncertainty(
@@ -329,18 +347,36 @@ class HyperparameterLikelihood(Likelihood):
             Dictionary containing arrays of size (n_posteriors, max_samples)
             There is a key for each shared key in posteriors.
         """
-        for posterior in posteriors:
-            max_samples = min(len(posterior), max_samples)
         data = {key: [] for key in posteriors[0]}
-        logger.debug(f"Downsampling to {max_samples} samples per posterior.")
-        self.samples_per_posterior = max_samples
-        for posterior in posteriors:
-            temp = posterior.sample(self.samples_per_posterior)
-            for key in data:
-                data[key].append(temp[key])
+
+        if self.equal_samples:
+            for posterior in posteriors:
+                max_samples = min(len(posterior), max_samples)
+            logger.debug(f"Downsampling to {max_samples} samples per posterior.")
+            self.samples_per_posterior = max_samples
+            transitions = None
+            for posterior in posteriors:
+                temp = posterior.sample(self.samples_per_posterior)
+                for key in data:
+                    data[key].append(temp[key])
+        else:
+            self.samples_per_posterior = np.asarray([
+                min(len(posterior), max_samples) for posterior in posteriors
+            ])
+            transitions = np.concat([
+                np.zeros(1), np.cumsum(self.samples_per_posterior)
+            ]).astype(int)
+            for posterior, nsamples in zip(posteriors, self.samples_per_posterior):
+                temp = posterior.sample(nsamples)
+                for key in data:
+                    data[key].extend(temp[key])
+            self.samples_per_posterior = xp.asarray(self.samples_per_posterior)
+            transitions = xp.asarray(transitions)
+
         for key in data:
-            data[key] = xp.array(data[key])
-        return data
+            data[key] = xp.asarray(data[key])
+
+        return data, transitions
 
     def posterior_predictive_resample(self, samples, return_weights=False):
         """
@@ -370,47 +406,78 @@ class HyperparameterLikelihood(Likelihood):
             samples = [dict(samples.iloc[ii]) for ii in range(len(samples))]
         elif isinstance(samples, dict):
             samples = [samples]
-        weights = xp.zeros((self.n_posteriors, self.samples_per_posterior))
+        if self.equal_samples:
+            weights = xp.zeros((self.n_posteriors, self.samples_per_posterior))
+        else:
+            weights = xp.zeros(int(xp.sum(self.samples_per_posterior)))
+
         event_weights = xp.zeros(self.n_posteriors)
         for sample in tqdm(samples):
             parameters, added_keys = self.conversion_function(sample.copy())
             new_weights = (
                 self.hyper_prior.prob(self.data, **parameters) / self.sampling_prior
             )
-            event_weights += xp.mean(new_weights, axis=-1)
-            new_weights = (new_weights.T / xp.sum(new_weights, axis=-1)).T
+            expectation = self._weight_expectation(new_weights)
+            event_weights += expectation
+            if self.equal_samples:
+                denominator = expectation * self.samples_per_posterior
+            else:
+                denominator = xp.concat([
+                    xp.ones(nsamples) * weight * nsamples
+                    for nsamples, weight in zip(self.samples_per_posterior, expectation)
+                ])
+            new_weights = (new_weights.T / denominator).T
             weights += new_weights
-        weights = (weights.T / xp.sum(weights, axis=-1)).T
+
         new_idxs = xp.empty_like(weights, dtype=int)
         for ii in range(self.n_posteriors):
+            if self.equal_samples:
+                sl = ii
+                start = 0
+                nsamples = self.samples_per_posterior
+            else:
+                sl = slice(self.transitions[ii], self.transitions[ii + 1])
+                start = self.transitions[ii]
+                nsamples = int(self.samples_per_posterior[ii])
+            wts = weights[sl]
+            wts /= wts.sum()
             if "jax" in xp.__name__:
                 from jax import random
 
                 rng_key = random.PRNGKey(np.random.randint(10000000))
-                new_idxs = new_idxs.at[ii].set(
+                new_idxs = new_idxs.at[sl].set(
                     random.choice(
                         rng_key,
-                        xp.arange(self.samples_per_posterior),
-                        shape=(self.samples_per_posterior,),
+                        xp.arange(nsamples) + start,
+                        shape=(nsamples,),
                         replace=True,
-                        p=weights[ii],
+                        p=wts,
                     )
                 )
             else:
-                new_idxs[ii] = xp.asarray(
+                new_idxs[sl] = xp.asarray(
                     np.random.choice(
-                        range(self.samples_per_posterior),
-                        size=self.samples_per_posterior,
+                        np.arange(nsamples) + start,
+                        size=nsamples,
                         replace=True,
-                        p=to_numpy(weights[ii]),
+                        p=to_numpy(wts),
                     )
                 )
-        new_samples = {
-            key: xp.vstack(
-                [self.data[key][ii, new_idxs[ii]] for ii in range(self.n_posteriors)]
-            )
-            for key in self.data
-        }
+
+        if self.equal_samples:
+            new_samples = {
+                key: xp.vstack(
+                    [self.data[key][ii, new_idxs[ii]] for ii in range(self.n_posteriors)]
+                )
+                for key in self.data
+            }
+        else:
+            new_samples = {
+                key: xp.vstack(
+                    [self.data[key][new_idxs] for ii in range(self.n_posteriors)]
+                )
+                for key in self.data
+            }
         event_weights = list(event_weights)
         weight_string = " ".join([f"{float(weight):.1f}" for weight in event_weights])
         logger.info(f"Resampling done, sum of weights for events are {weight_string}")

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -204,7 +204,7 @@ class HyperparameterLikelihood(Likelihood):
         weights = self.hyper_prior.prob(self.data, **parameters) / self.sampling_prior
         expectation = self._weight_expectation(weights)
         if return_uncertainty:
-            square_expectation = self._weight_expectation(weights)
+            square_expectation = self._weight_expectation(weights**2)
             variance = (square_expectation - expectation**2) / (
                 self.samples_per_posterior * expectation**2
             )
@@ -218,8 +218,7 @@ class HyperparameterLikelihood(Likelihood):
         else:
             cumulative = xp.concat([xp.zeros(1), xp.cumsum(weights)])
             expectation = (
-                cumulative[self.transitions[1:]]
-                - cumulative[self.transitions[:-1]]
+                cumulative[self.transitions[1:]] - cumulative[self.transitions[:-1]]
             ) / self.samples_per_posterior
         return expectation
 
@@ -360,12 +359,12 @@ class HyperparameterLikelihood(Likelihood):
                 for key in data:
                     data[key].append(temp[key])
         else:
-            self.samples_per_posterior = np.asarray([
-                min(len(posterior), max_samples) for posterior in posteriors
-            ])
-            transitions = np.concat([
-                np.zeros(1), np.cumsum(self.samples_per_posterior)
-            ]).astype(int)
+            self.samples_per_posterior = np.asarray(
+                [min(len(posterior), max_samples) for posterior in posteriors]
+            )
+            transitions = np.concat(
+                [np.zeros(1), np.cumsum(self.samples_per_posterior)]
+            ).astype(int)
             for posterior, nsamples in zip(posteriors, self.samples_per_posterior):
                 temp = posterior.sample(nsamples)
                 for key in data:
@@ -422,10 +421,14 @@ class HyperparameterLikelihood(Likelihood):
             if self.equal_samples:
                 denominator = expectation * self.samples_per_posterior
             else:
-                denominator = xp.concat([
-                    xp.ones(nsamples) * weight * nsamples
-                    for nsamples, weight in zip(self.samples_per_posterior, expectation)
-                ])
+                denominator = xp.concat(
+                    [
+                        xp.ones(nsamples) * weight * nsamples
+                        for nsamples, weight in zip(
+                            self.samples_per_posterior, expectation
+                        )
+                    ]
+                )
             new_weights = (new_weights.T / denominator).T
             weights += new_weights
 
@@ -467,7 +470,10 @@ class HyperparameterLikelihood(Likelihood):
         if self.equal_samples:
             new_samples = {
                 key: xp.vstack(
-                    [self.data[key][ii, new_idxs[ii]] for ii in range(self.n_posteriors)]
+                    [
+                        self.data[key][ii, new_idxs[ii]]
+                        for ii in range(self.n_posteriors)
+                    ]
                 )
                 for key in self.data
             }

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -113,9 +113,7 @@ class HyperparameterLikelihood(Likelihood):
 
         self.samples_per_posterior = max_samples
         self.equal_samples = require_equal_samples
-        self.data, self.transitions = self.resample_posteriors(
-            posteriors, max_samples=max_samples
-        )
+        self.data = self.resample_posteriors(posteriors, max_samples=max_samples)
 
         if isinstance(hyper_prior, types.FunctionType):
             hyper_prior = Model([hyper_prior])
@@ -217,8 +215,11 @@ class HyperparameterLikelihood(Likelihood):
             expectation = xp.mean(weights, axis=-1)
         else:
             cumulative = xp.concat([xp.zeros(1), xp.cumsum(weights)])
+            transitions = xp.concat(
+                [xp.zeros(1), xp.cumsum(self.samples_per_posterior)]
+            ).astype(int)
             expectation = (
-                cumulative[self.transitions[1:]] - cumulative[self.transitions[:-1]]
+                cumulative[transitions[1:]] - cumulative[transitions[:-1]]
             ) / self.samples_per_posterior
         return expectation
 
@@ -352,7 +353,6 @@ class HyperparameterLikelihood(Likelihood):
                 max_samples = min(len(posterior), max_samples)
             logger.debug(f"Downsampling to {max_samples} samples per posterior.")
             self.samples_per_posterior = max_samples
-            transitions = None
             for posterior in posteriors:
                 temp = posterior.sample(self.samples_per_posterior)
                 for key in data:
@@ -369,12 +369,11 @@ class HyperparameterLikelihood(Likelihood):
                 for key in data:
                     data[key].extend(temp[key])
             self.samples_per_posterior = xp.asarray(self.samples_per_posterior)
-            transitions = xp.asarray(transitions)
 
         for key in data:
             data[key] = xp.asarray(data[key])
 
-        return data, transitions
+        return data
 
     def posterior_predictive_resample(self, samples, return_weights=False):
         """
@@ -438,8 +437,11 @@ class HyperparameterLikelihood(Likelihood):
                 start = 0
                 nsamples = self.samples_per_posterior
             else:
-                sl = slice(self.transitions[ii], self.transitions[ii + 1])
-                start = self.transitions[ii]
+                transitions = np.concat(
+                    [xp.zeros(1), xp.cumsum(self.samples_per_posterior)]
+                ).astype(int)
+                sl = slice(transitions[ii], transitions[ii + 1])
+                start = transitions[ii]
                 nsamples = int(self.samples_per_posterior[ii])
             wts = weights[sl]
             wts /= wts.sum()

--- a/gwpopulation/hyperpe.py
+++ b/gwpopulation/hyperpe.py
@@ -107,7 +107,7 @@ class HyperparameterLikelihood(Likelihood):
             If the uncertainty is larger than this value a log likelihood of
             -inf will be returned. Default = inf
         require_equal_samples: bool
-            Whether to require and equal number of samples per posterior.
+            Whether to require an equal number of samples per posterior.
             Set to :code:`True` for backward compatibility.
         """
 
@@ -337,8 +337,7 @@ class HyperparameterLikelihood(Likelihood):
         posteriors: list
             List of pandas DataFrame objects.
         max_samples: int, opt
-            Maximum number of samples to take from each posterior,
-            default is length of shortest posterior chain.
+            Maximum number of samples to take from each posterior.
 
         Returns
         -------
@@ -478,12 +477,7 @@ class HyperparameterLikelihood(Likelihood):
                 for key in self.data
             }
         else:
-            new_samples = {
-                key: xp.vstack(
-                    [self.data[key][new_idxs] for ii in range(self.n_posteriors)]
-                )
-                for key in self.data
-            }
+            new_samples = {key: self.data[key][new_idxs] for key in self.data}
         event_weights = list(event_weights)
         weight_string = " ".join([f"{float(weight):.1f}" for weight in event_weights])
         logger.info(f"Resampling done, sum of weights for events are {weight_string}")

--- a/test/example_test.py
+++ b/test/example_test.py
@@ -9,8 +9,10 @@ import gwpopulation
 from gwpopulation.experimental.jax import JittedLikelihood
 
 
-@pytest.mark.parametrize("jit", [True, False])
-def test_likelihood_evaluation(backend, jit):
+@pytest.mark.parametrize(
+    "jit, equal", [[True, True], [True, False], [False, True], [False, False]]
+)
+def test_likelihood_evaluation(backend, jit, equal):
     if backend != "jax" and jit:
         pytest.skip(reason="JIT only works with JAX")
 
@@ -67,6 +69,7 @@ def test_likelihood_evaluation(backend, jit):
         hyper_prior=model,
         posteriors=posteriors,
         selection_function=selection,
+        require_equal_samples=equal,
     )
 
     priors = bilby.core.prior.PriorDict("priors/bbh_population.prior")

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -86,7 +86,10 @@ class Likelihoods(unittest.TestCase):
 
     def test_hpe_likelihood_set_max_samples(self):
         like = HyperparameterLikelihood(
-            posteriors=self.data, hyper_prior=self.model, max_samples=10, require_equal_samples=True
+            posteriors=self.data,
+            hyper_prior=self.model,
+            max_samples=10,
+            require_equal_samples=True,
         )
         self.assertEqual(like.data["a"].shape, (5, 10))
 

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -86,7 +86,7 @@ class Likelihoods(unittest.TestCase):
 
     def test_hpe_likelihood_set_max_samples(self):
         like = HyperparameterLikelihood(
-            posteriors=self.data, hyper_prior=self.model, max_samples=10
+            posteriors=self.data, hyper_prior=self.model, max_samples=10, require_equal_samples=True
         )
         self.assertEqual(like.data["a"].shape, (5, 10))
 
@@ -204,6 +204,7 @@ class Likelihoods(unittest.TestCase):
             hyper_prior=self.model,
             selection_function=self.selection_function,
             ln_evidences=self.ln_evidences,
+            require_equal_samples=True,
         )
         new_samples = like.posterior_predictive_resample(samples=samples)
         for key in new_samples:
@@ -216,6 +217,7 @@ class Likelihoods(unittest.TestCase):
             hyper_prior=model,
             selection_function=self.selection_function,
             ln_evidences=self.ln_evidences,
+            require_equal_samples=True,
         )
         expected = dict(
             model=["<lambda>", "SinglePeakSmoothedMassDistribution"],

--- a/test/likelihood_test.py
+++ b/test/likelihood_test.py
@@ -23,6 +23,8 @@ class Likelihoods(unittest.TestCase):
         self.model = lambda dataset, a, b, c: dataset["a"]
         one_data = pd.DataFrame({key: xp.ones(500) for key in self.params})
         self.data = [one_data] * 5
+        self.sample_lengths = [100, 123, 459, 43, 233]
+        self.unequal_data = [one_data[:ns] for ns in self.sample_lengths]
         self.ln_evidences = [0] * 5
         self.selection_function = lambda args: 2.0
         self.conversion_function = lambda args: (args, ["bar"])
@@ -92,6 +94,15 @@ class Likelihoods(unittest.TestCase):
             require_equal_samples=True,
         )
         self.assertEqual(like.data["a"].shape, (5, 10))
+
+    def test_hpe_likelihood_unequal_samples(self):
+        like = HyperparameterLikelihood(
+            posteriors=self.unequal_data,
+            hyper_prior=self.model,
+            require_equal_samples=False,
+        )
+        for value in like.data.values():
+            self.assertEqual(value.shape, (sum(self.sample_lengths),))
 
     def test_hpe_likelihood_log_likelihood_ratio(self):
         like = HyperparameterLikelihood(posteriors=self.data, hyper_prior=self.model)
@@ -208,6 +219,20 @@ class Likelihoods(unittest.TestCase):
             selection_function=self.selection_function,
             ln_evidences=self.ln_evidences,
             require_equal_samples=True,
+        )
+        new_samples = like.posterior_predictive_resample(samples=samples)
+        for key in new_samples:
+            self.assertEqual(new_samples[key].shape, like.data[key].shape)
+
+    def test_resampling_unequal_posteriors(self):
+        priors = PriorDict(dict(a=Uniform(0, 2), b=Uniform(0, 2), c=Uniform(0, 2)))
+        samples = priors.sample(100)
+        like = HyperparameterLikelihood(
+            posteriors=self.unequal_data,
+            hyper_prior=self.model,
+            selection_function=self.selection_function,
+            ln_evidences=self.ln_evidences,
+            require_equal_samples=False,
         )
         new_samples = like.posterior_predictive_resample(samples=samples)
         for key in new_samples:


### PR DESCRIPTION
This uses an approach suggested by @mdmould to allow different numbers of samples per event.

@mdmould, do you think you could take a look at this?